### PR TITLE
[Feat] Shop 관련 기능 구현

### DIFF
--- a/src/main/java/com/roome/roome/be/common/config/SecurityConfig.java
+++ b/src/main/java/com/roome/roome/be/common/config/SecurityConfig.java
@@ -64,6 +64,7 @@ public class SecurityConfig {
                         .requestMatchers(AUTH_URIS).permitAll()
                         .requestMatchers(ACTUATOR_URIS).permitAll()
                         .requestMatchers("/api/auth/**").permitAll() // 혹시 빠진 URI 커버
+                        .requestMatchers("/admin/**").hasRole("ADMIN")
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/com/roome/roome/be/common/jwt/JwtFilter.java
+++ b/src/main/java/com/roome/roome/be/common/jwt/JwtFilter.java
@@ -1,25 +1,28 @@
 package com.roome.roome.be.common.jwt;
 
+import java.io.IOException;
+import java.util.List;
+
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.roome.roome.be.common.base.BaseStatus;
 import com.roome.roome.be.common.exception.GeneralException;
 import com.roome.roome.be.common.response.ApiResponse;
 import com.roome.roome.be.common.status.ErrorStatus;
+
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.MediaType;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
-import org.springframework.stereotype.Component;
-import org.springframework.web.filter.OncePerRequestFilter;
-
-import java.io.IOException;
-import java.util.Collections;
 
 @Slf4j
 @Component
@@ -41,9 +44,13 @@ public class JwtFilter extends OncePerRequestFilter {
             if (jwt != null) {
                 jwtService.validateJwtToken(jwt);
                 Long userId = jwtService.getUserIdFromJwtToken(jwt);
+                String role = jwtService.getRoleFromJwtToken(jwt);
+
+                List<SimpleGrantedAuthority> authorities =
+                    List.of(new SimpleGrantedAuthority("ROLE_" + role));
 
                 UsernamePasswordAuthenticationToken authentication =
-                        new UsernamePasswordAuthenticationToken(userId, null, Collections.emptyList());
+                        new UsernamePasswordAuthenticationToken(userId, null, authorities);
                 authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
 
                 SecurityContextHolder.getContext().setAuthentication(authentication);

--- a/src/main/java/com/roome/roome/be/common/jwt/JwtService.java
+++ b/src/main/java/com/roome/roome/be/common/jwt/JwtService.java
@@ -88,7 +88,6 @@ public class JwtService {
     }
 
     /** JWT 토큰에서 role 추출 */
-    /** JWT 토큰에서 role 추출 */
     public String getRoleFromJwtToken(String token) {
         try {
             return Jwts.parserBuilder()

--- a/src/main/java/com/roome/roome/be/common/jwt/JwtService.java
+++ b/src/main/java/com/roome/roome/be/common/jwt/JwtService.java
@@ -39,6 +39,7 @@ public class JwtService {
                 .claim("email", user.getEmail())
                 .claim("nickname", user.getNickname())
                 .claim("loginType", user.getLoginType().name())
+                .claim("role", user.getRole().name())
                 .setIssuedAt(now)
                 .setExpiration(expiry)
                 .signWith(secretKey, SignatureAlgorithm.HS256)
@@ -86,6 +87,21 @@ public class JwtService {
         }
     }
 
+    /** JWT 토큰에서 role 추출 */
+    /** JWT 토큰에서 role 추출 */
+    public String getRoleFromJwtToken(String token) {
+        try {
+            return Jwts.parserBuilder()
+                .setSigningKey(secretKey)
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .get("role", String.class);
+        } catch (Exception e) {
+            throw new GeneralException(ErrorStatus.JWT_EXTRACT_ROLE_FAILED);
+        }
+    }
+
     /** 내부 Claims 파싱 로직, 만료된 토큰, 서명 불일치 등 예외 시 GeneralException 처리 */
     private Claims getClaims(String token) {
         try {
@@ -114,4 +130,5 @@ public class JwtService {
             throw new GeneralException(ErrorStatus.JWT_GENERAL_ERROR);
         }
     }
+
 }

--- a/src/main/java/com/roome/roome/be/common/status/ErrorStatus.java
+++ b/src/main/java/com/roome/roome/be/common/status/ErrorStatus.java
@@ -59,7 +59,8 @@ public enum ErrorStatus implements BaseStatus {
     JWT_GENERAL_ERROR("JWT_401", HttpStatus.UNAUTHORIZED, "JWT 토큰 처리 중 알 수 없는 오류가 발생했습니다."),
     JWT_INVALID_TYPE("JWT_401", HttpStatus.UNAUTHORIZED, "토큰 타입이 유효하지 않습니다."),
     REFRESH_TOKEN_NOT_FOUND("JWT_401", HttpStatus.UNAUTHORIZED, "DB에 저장된 토큰과 일치하지 않습니다."),
-    REFRESH_TOKEN_MISMATCH("JWT_401", HttpStatus.UNAUTHORIZED, "리프레시 토큰 정보가 사용자 정보와 일치하지 않습니다.");
+    REFRESH_TOKEN_MISMATCH("JWT_401", HttpStatus.UNAUTHORIZED, "리프레시 토큰 정보가 사용자 정보와 일치하지 않습니다."),
+    JWT_EXTRACT_ROLE_FAILED("JWT_401", HttpStatus.UNAUTHORIZED, "토큰에서 사용자 Role을 추출할 수 없습니다.");
 
     private final String code;
     private final HttpStatus httpStatus;

--- a/src/main/java/com/roome/roome/be/common/status/ErrorStatus.java
+++ b/src/main/java/com/roome/roome/be/common/status/ErrorStatus.java
@@ -60,7 +60,12 @@ public enum ErrorStatus implements BaseStatus {
     JWT_INVALID_TYPE("JWT_401", HttpStatus.UNAUTHORIZED, "토큰 타입이 유효하지 않습니다."),
     REFRESH_TOKEN_NOT_FOUND("JWT_401", HttpStatus.UNAUTHORIZED, "DB에 저장된 토큰과 일치하지 않습니다."),
     REFRESH_TOKEN_MISMATCH("JWT_401", HttpStatus.UNAUTHORIZED, "리프레시 토큰 정보가 사용자 정보와 일치하지 않습니다."),
-    JWT_EXTRACT_ROLE_FAILED("JWT_401", HttpStatus.UNAUTHORIZED, "토큰에서 사용자 Role을 추출할 수 없습니다.");
+    JWT_EXTRACT_ROLE_FAILED("JWT_401", HttpStatus.UNAUTHORIZED, "토큰에서 사용자 Role을 추출할 수 없습니다."),
+
+    /**
+     * Shop
+     */
+    SHOP_NOT_FOUND("SHOP_404", HttpStatus.NOT_FOUND, "존재하지 않는 가게입니다.");
 
     private final String code;
     private final HttpStatus httpStatus;

--- a/src/main/java/com/roome/roome/be/common/status/SuccessStatus.java
+++ b/src/main/java/com/roome/roome/be/common/status/SuccessStatus.java
@@ -33,7 +33,12 @@ public enum SuccessStatus implements BaseStatus {
     /**
      * User
      */
-    SAVE_USER_ONBOARDING("AUTH_201", HttpStatus.CREATED, "유저 온보딩 저장 성공");
+    SAVE_USER_ONBOARDING("AUTH_201", HttpStatus.CREATED, "유저 온보딩 저장 성공"),
+
+    /**
+     * Shop
+     */
+    REGISTER_SHOP_SUCCESS("SHOP_201", HttpStatus.CREATED, "가게 등록 성공");
 
     private final String code;
     private final HttpStatus httpStatus;

--- a/src/main/java/com/roome/roome/be/common/status/SuccessStatus.java
+++ b/src/main/java/com/roome/roome/be/common/status/SuccessStatus.java
@@ -41,7 +41,8 @@ public enum SuccessStatus implements BaseStatus {
     REGISTER_SHOP_SUCCESS("SHOP_201", HttpStatus.CREATED, "가게 등록 성공"),
     UPDATE_SHOP_SUCCESS("SHOP_200", HttpStatus.OK, "가게 수정 성공"),
     DELETE_SHOP_SUCCESS("SHOP_200", HttpStatus.OK, "가게 삭제 성공"),
-    GET_SHOP_DETAIL_SUCCESS("SHOP_200",HttpStatus.OK ,"가게 상세 조회 성공" );
+    GET_SHOP_DETAIL_SUCCESS("SHOP_200",HttpStatus.OK ,"가게 상세 조회 성공" ),
+    GET_SHOP_LIST_SUCCESS("SHOP_200",HttpStatus.OK ,"가게 목록 조회 성공" );
 
     private final String code;
     private final HttpStatus httpStatus;

--- a/src/main/java/com/roome/roome/be/common/status/SuccessStatus.java
+++ b/src/main/java/com/roome/roome/be/common/status/SuccessStatus.java
@@ -38,7 +38,9 @@ public enum SuccessStatus implements BaseStatus {
     /**
      * Shop
      */
-    REGISTER_SHOP_SUCCESS("SHOP_201", HttpStatus.CREATED, "가게 등록 성공");
+    REGISTER_SHOP_SUCCESS("SHOP_201", HttpStatus.CREATED, "가게 등록 성공"),
+    UPDATE_SHOP_SUCCESS("SHOP_200", HttpStatus.OK, "가게 수정 성공"),
+    DELETE_SHOP_SUCCESS("SHOP_200", HttpStatus.OK, "가게 삭제 성공");
 
     private final String code;
     private final HttpStatus httpStatus;

--- a/src/main/java/com/roome/roome/be/common/status/SuccessStatus.java
+++ b/src/main/java/com/roome/roome/be/common/status/SuccessStatus.java
@@ -40,7 +40,8 @@ public enum SuccessStatus implements BaseStatus {
      */
     REGISTER_SHOP_SUCCESS("SHOP_201", HttpStatus.CREATED, "가게 등록 성공"),
     UPDATE_SHOP_SUCCESS("SHOP_200", HttpStatus.OK, "가게 수정 성공"),
-    DELETE_SHOP_SUCCESS("SHOP_200", HttpStatus.OK, "가게 삭제 성공");
+    DELETE_SHOP_SUCCESS("SHOP_200", HttpStatus.OK, "가게 삭제 성공"),
+    GET_SHOP_DETAIL_SUCCESS("SHOP_200",HttpStatus.OK ,"가게 상세 조회 성공" );
 
     private final String code;
     private final HttpStatus httpStatus;

--- a/src/main/java/com/roome/roome/be/domain/shop/controller/AdminShopController.java
+++ b/src/main/java/com/roome/roome/be/domain/shop/controller/AdminShopController.java
@@ -31,6 +31,7 @@ public class AdminShopController {
 
 	private final ShopService shopService;
 
+    //가게 등록
 	@PostMapping
 	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "가게 등록 성공", content = @Content)
 	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청 데이터", content = @Content)
@@ -42,6 +43,7 @@ public class AdminShopController {
 		return ApiResponse.success(SuccessStatus.REGISTER_SHOP_SUCCESS, shopRegisterResponse);
 	}
 
+	// 가게 정보 수정
 	@PatchMapping("/{shopId}")
 	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "가게 수정 성공", content = @Content)
 	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "가게가 존재하지 않는 경우", content = @Content)
@@ -52,5 +54,17 @@ public class AdminShopController {
 	) {
 		shopService.updateShop(shopId, shopUpdateRequest);
 		return ApiResponse.success(SuccessStatus.UPDATE_SHOP_SUCCESS);
+	}
+
+	//가게 삭제
+	@DeleteMapping("/{shopId}")
+	@Operation(summary = "가게 삭제 (관리자)")
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "가게 삭제 성공", content = @Content)
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "가게가 존재하지 않는 경우", content = @Content)
+	public ResponseEntity<ApiResponse<Void>> deleteShop(
+		@PathVariable Long shopId
+	) {
+		shopService.deleteShop(shopId);
+		return ApiResponse.success(SuccessStatus.DELETE_SHOP_SUCCESS);
 	}
 }

--- a/src/main/java/com/roome/roome/be/domain/shop/controller/AdminShopController.java
+++ b/src/main/java/com/roome/roome/be/domain/shop/controller/AdminShopController.java
@@ -1,0 +1,40 @@
+package com.roome.roome.be.domain.shop.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.roome.roome.be.common.response.ApiResponse;
+import com.roome.roome.be.common.status.SuccessStatus;
+import com.roome.roome.be.domain.shop.dto.request.ShopRegisterRequest;
+import com.roome.roome.be.domain.shop.dto.response.ShopRegisterResponse;
+import com.roome.roome.be.domain.shop.service.ShopService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin/shop")
+@Tag(name = "Shop", description = "가게 API")
+public class AdminShopController {
+
+	private final ShopService shopService;
+
+	@PostMapping
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "가게 등록 성공", content = @Content)
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청 데이터", content = @Content)
+	@Operation(summary = "가게 등록 (관리자)")
+	public ResponseEntity<ApiResponse<ShopRegisterResponse>> registerShop(
+		@Valid @RequestBody ShopRegisterRequest shopRegisterRequest
+	) {
+		ShopRegisterResponse shopRegisterResponse = shopService.registerShop(shopRegisterRequest);
+		return ApiResponse.success(SuccessStatus.REGISTER_SHOP_SUCCESS, shopRegisterResponse);
+	}
+}

--- a/src/main/java/com/roome/roome/be/domain/shop/controller/AdminShopController.java
+++ b/src/main/java/com/roome/roome/be/domain/shop/controller/AdminShopController.java
@@ -1,6 +1,9 @@
 package com.roome.roome.be.domain.shop.controller;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -9,6 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.roome.roome.be.common.response.ApiResponse;
 import com.roome.roome.be.common.status.SuccessStatus;
 import com.roome.roome.be.domain.shop.dto.request.ShopRegisterRequest;
+import com.roome.roome.be.domain.shop.dto.request.ShopUpdateRequest;
 import com.roome.roome.be.domain.shop.dto.response.ShopRegisterResponse;
 import com.roome.roome.be.domain.shop.service.ShopService;
 
@@ -36,5 +40,17 @@ public class AdminShopController {
 	) {
 		ShopRegisterResponse shopRegisterResponse = shopService.registerShop(shopRegisterRequest);
 		return ApiResponse.success(SuccessStatus.REGISTER_SHOP_SUCCESS, shopRegisterResponse);
+	}
+
+	@PatchMapping("/{shopId}")
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "가게 수정 성공", content = @Content)
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "가게가 존재하지 않는 경우", content = @Content)
+	@Operation(summary = "가게 이름 수정 (관리자)")
+	public ResponseEntity<ApiResponse<Void>> updateShop(
+		@PathVariable Long shopId,
+		@RequestBody ShopUpdateRequest shopUpdateRequest
+	) {
+		shopService.updateShop(shopId, shopUpdateRequest);
+		return ApiResponse.success(SuccessStatus.UPDATE_SHOP_SUCCESS);
 	}
 }

--- a/src/main/java/com/roome/roome/be/domain/shop/controller/ShopController.java
+++ b/src/main/java/com/roome/roome/be/domain/shop/controller/ShopController.java
@@ -3,21 +3,20 @@ package com.roome.roome.be.domain.shop.controller;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.roome.roome.be.common.response.ApiResponse;
 import com.roome.roome.be.common.status.SuccessStatus;
-import com.roome.roome.be.domain.shop.dto.request.ShopRegisterRequest;
 import com.roome.roome.be.domain.shop.dto.response.ShopDetailResponse;
-import com.roome.roome.be.domain.shop.dto.response.ShopRegisterResponse;
+import com.roome.roome.be.domain.shop.dto.response.ShopListResponse;
 import com.roome.roome.be.domain.shop.service.ShopService;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -42,5 +41,20 @@ public class ShopController {
 		);
 	}
 
+	// 가게 목록 조회
+	@GetMapping
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "가게 상세 조회 성공", content = @Content)
+	@Operation(summary = "가게 목록 조회: 페이지 최근 가게부터 보여줌(역순)")
+	public ResponseEntity<ApiResponse<ShopListResponse>> getShops(
+		@Parameter(description = "조회할 페이지 번호 (0부터 시작)", example = "0")
+		@RequestParam(defaultValue = "0") int page,
+		@Parameter(description = "페이지당 항목 개수", example = "10")
+		@RequestParam(defaultValue = "10") int size,
+		@Parameter(description = "가게 이름 검색어(선택사항), 포함된 검색어가 있으면 반환", example = "이케아")
+		@RequestParam(required = false) String name
+	) {
+		ShopListResponse shopListResponse = shopService.getShopList(page, size, name);
+		return ApiResponse.success(SuccessStatus.GET_SHOP_LIST_SUCCESS, shopListResponse);
+	}
 
 }

--- a/src/main/java/com/roome/roome/be/domain/shop/controller/ShopController.java
+++ b/src/main/java/com/roome/roome/be/domain/shop/controller/ShopController.java
@@ -1,0 +1,46 @@
+package com.roome.roome.be.domain.shop.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.roome.roome.be.common.response.ApiResponse;
+import com.roome.roome.be.common.status.SuccessStatus;
+import com.roome.roome.be.domain.shop.dto.request.ShopRegisterRequest;
+import com.roome.roome.be.domain.shop.dto.response.ShopDetailResponse;
+import com.roome.roome.be.domain.shop.dto.response.ShopRegisterResponse;
+import com.roome.roome.be.domain.shop.service.ShopService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/shop")
+@Tag(name = "Shop", description = "일반 조회 가게 API")
+public class ShopController {
+
+	private final ShopService shopService;
+
+    //가게 상세 조회
+	@GetMapping("/{shopId}")
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "가게 상세 조회 성공", content = @Content)
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청 데이터", content = @Content)
+	@Operation(summary = "가게 상세 조회")
+	public ResponseEntity<ApiResponse<ShopDetailResponse>> getShop(
+		@PathVariable Long shopId
+	) {
+		return ApiResponse.success(
+			SuccessStatus.GET_SHOP_DETAIL_SUCCESS,
+			shopService.getShopDetail(shopId)
+		);
+	}
+
+
+}

--- a/src/main/java/com/roome/roome/be/domain/shop/dto/request/ShopRegisterRequest.java
+++ b/src/main/java/com/roome/roome/be/domain/shop/dto/request/ShopRegisterRequest.java
@@ -1,0 +1,8 @@
+package com.roome.roome.be.domain.shop.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record ShopRegisterRequest (
+	@NotBlank(message = "가게 이름은 필수입니다.")
+	String name
+){}

--- a/src/main/java/com/roome/roome/be/domain/shop/dto/request/ShopUpdateRequest.java
+++ b/src/main/java/com/roome/roome/be/domain/shop/dto/request/ShopUpdateRequest.java
@@ -1,0 +1,5 @@
+package com.roome.roome.be.domain.shop.dto.request;
+
+public record ShopUpdateRequest(
+	String name
+){}

--- a/src/main/java/com/roome/roome/be/domain/shop/dto/response/ShopDetailResponse.java
+++ b/src/main/java/com/roome/roome/be/domain/shop/dto/response/ShopDetailResponse.java
@@ -1,0 +1,15 @@
+package com.roome.roome.be.domain.shop.dto.response;
+
+import com.roome.roome.be.domain.shop.entity.Shop;
+
+public record ShopDetailResponse(
+	Long id,
+	String name
+) {
+	public static ShopDetailResponse from(Shop shop) {
+		return new ShopDetailResponse(
+			shop.getId(),
+			shop.getName()
+		);
+	}
+}

--- a/src/main/java/com/roome/roome/be/domain/shop/dto/response/ShopListResponse.java
+++ b/src/main/java/com/roome/roome/be/domain/shop/dto/response/ShopListResponse.java
@@ -1,0 +1,11 @@
+package com.roome.roome.be.domain.shop.dto.response;
+
+import java.util.List;
+
+public record ShopListResponse(
+	List<ShopSummaryResponse> content,
+	int page,
+	int size,
+	long totalElements
+) {
+}

--- a/src/main/java/com/roome/roome/be/domain/shop/dto/response/ShopRegisterResponse.java
+++ b/src/main/java/com/roome/roome/be/domain/shop/dto/response/ShopRegisterResponse.java
@@ -1,0 +1,12 @@
+package com.roome.roome.be.domain.shop.dto.response;
+
+import com.roome.roome.be.domain.shop.entity.Shop;
+
+public record ShopRegisterResponse(
+	Long shopId,
+	String name
+) {
+	public static ShopRegisterResponse from(Shop shop) {
+		return new ShopRegisterResponse(shop.getId(), shop.getName());
+	}
+}

--- a/src/main/java/com/roome/roome/be/domain/shop/dto/response/ShopSummaryResponse.java
+++ b/src/main/java/com/roome/roome/be/domain/shop/dto/response/ShopSummaryResponse.java
@@ -1,0 +1,15 @@
+package com.roome.roome.be.domain.shop.dto.response;
+
+import com.roome.roome.be.domain.shop.entity.Shop;
+
+public record ShopSummaryResponse(
+	Long id,
+	String name
+) {
+	public static ShopSummaryResponse from(Shop shop) {
+		return new ShopSummaryResponse(
+			shop.getId(),
+			shop.getName()
+		);
+	}
+}

--- a/src/main/java/com/roome/roome/be/domain/shop/entity/Shop.java
+++ b/src/main/java/com/roome/roome/be/domain/shop/entity/Shop.java
@@ -27,4 +27,8 @@ public class Shop extends BaseEntity {
 	@Column(nullable = false, length = 50)
 	private String name;
 
+	public void updateName(String name) {
+		this.name = name;
+	}
+
 }

--- a/src/main/java/com/roome/roome/be/domain/shop/repository/ShopRepository.java
+++ b/src/main/java/com/roome/roome/be/domain/shop/repository/ShopRepository.java
@@ -1,9 +1,12 @@
 package com.roome.roome.be.domain.shop.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.roome.roome.be.domain.shop.entity.Shop;
 
 public interface ShopRepository extends JpaRepository<Shop, Long> {
 
+	Page<Shop> findByNameContaining(String name, Pageable pageable);
 }

--- a/src/main/java/com/roome/roome/be/domain/shop/repository/ShopRepository.java
+++ b/src/main/java/com/roome/roome/be/domain/shop/repository/ShopRepository.java
@@ -1,0 +1,9 @@
+package com.roome.roome.be.domain.shop.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.roome.roome.be.domain.shop.entity.Shop;
+
+public interface ShopRepository extends JpaRepository<Shop, Long> {
+
+}

--- a/src/main/java/com/roome/roome/be/domain/shop/service/ShopService.java
+++ b/src/main/java/com/roome/roome/be/domain/shop/service/ShopService.java
@@ -41,4 +41,12 @@ public class ShopService {
 		}
 	}
 
+	//가게 삭제
+	@Transactional
+	public void deleteShop(Long shopId) {
+		Shop shop = shopRepository.findById(shopId)
+			.orElseThrow(() -> new GeneralException(ErrorStatus.SHOP_NOT_FOUND));
+
+		shopRepository.delete(shop);
+	}
 }

--- a/src/main/java/com/roome/roome/be/domain/shop/service/ShopService.java
+++ b/src/main/java/com/roome/roome/be/domain/shop/service/ShopService.java
@@ -1,17 +1,26 @@
 package com.roome.roome.be.domain.shop.service;
 
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.roome.roome.be.common.exception.GeneralException;
 import com.roome.roome.be.common.status.ErrorStatus;
 import com.roome.roome.be.domain.shop.dto.request.ShopRegisterRequest;
 import com.roome.roome.be.domain.shop.dto.request.ShopUpdateRequest;
 import com.roome.roome.be.domain.shop.dto.response.ShopDetailResponse;
+import com.roome.roome.be.domain.shop.dto.response.ShopListResponse;
 import com.roome.roome.be.domain.shop.dto.response.ShopRegisterResponse;
+import com.roome.roome.be.domain.shop.dto.response.ShopSummaryResponse;
 import com.roome.roome.be.domain.shop.entity.Shop;
 import com.roome.roome.be.domain.shop.repository.ShopRepository;
 
-import jakarta.transaction.Transactional;
+
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -52,12 +61,37 @@ public class ShopService {
 	}
 
 	//가게 상세 조회, 추후 상세 내용 보완
-	@Transactional
+	@Transactional(readOnly=true)
 	public ShopDetailResponse getShopDetail(Long shopId){
 		Shop shop = shopRepository.findById(shopId)
 			.orElseThrow(() -> new GeneralException(ErrorStatus.SHOP_NOT_FOUND));
 		return ShopDetailResponse.from(shop);
 
+	}
+
+	//가게 목록 조회
+	@Transactional(readOnly = true)
+	public ShopListResponse getShopList(int page, int size, String name) {
+		Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "id"));
+
+		Page<Shop> shops;
+		if (name != null && !name.isBlank()) {
+			shops = shopRepository.findByNameContaining(name, pageable);
+		} else {
+			shops = shopRepository.findAll(pageable);
+		}
+
+		List<ShopSummaryResponse> content = shops
+			.stream()
+			.map(ShopSummaryResponse::from)
+			.toList();
+
+		return new ShopListResponse(
+			content,
+			shops.getNumber(),
+			shops.getSize(),
+			shops.getTotalElements()
+		);
 	}
 
 }

--- a/src/main/java/com/roome/roome/be/domain/shop/service/ShopService.java
+++ b/src/main/java/com/roome/roome/be/domain/shop/service/ShopService.java
@@ -1,0 +1,28 @@
+package com.roome.roome.be.domain.shop.service;
+
+import org.springframework.stereotype.Service;
+
+import com.roome.roome.be.domain.shop.dto.request.ShopRegisterRequest;
+import com.roome.roome.be.domain.shop.dto.response.ShopRegisterResponse;
+import com.roome.roome.be.domain.shop.entity.Shop;
+import com.roome.roome.be.domain.shop.repository.ShopRepository;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ShopService {
+
+	private final ShopRepository shopRepository;
+
+	@Transactional
+	public ShopRegisterResponse registerShop(ShopRegisterRequest shopRegisterRequest) {
+		Shop shop = Shop.builder()
+			.name(shopRegisterRequest.name())
+			.build();
+
+		Shop savedShop = shopRepository.save(shop);
+		return ShopRegisterResponse.from(savedShop);
+	}
+}

--- a/src/main/java/com/roome/roome/be/domain/shop/service/ShopService.java
+++ b/src/main/java/com/roome/roome/be/domain/shop/service/ShopService.java
@@ -6,6 +6,7 @@ import com.roome.roome.be.common.exception.GeneralException;
 import com.roome.roome.be.common.status.ErrorStatus;
 import com.roome.roome.be.domain.shop.dto.request.ShopRegisterRequest;
 import com.roome.roome.be.domain.shop.dto.request.ShopUpdateRequest;
+import com.roome.roome.be.domain.shop.dto.response.ShopDetailResponse;
 import com.roome.roome.be.domain.shop.dto.response.ShopRegisterResponse;
 import com.roome.roome.be.domain.shop.entity.Shop;
 import com.roome.roome.be.domain.shop.repository.ShopRepository;
@@ -49,4 +50,14 @@ public class ShopService {
 
 		shopRepository.delete(shop);
 	}
+
+	//가게 상세 조회, 추후 상세 내용 보완
+	@Transactional
+	public ShopDetailResponse getShopDetail(Long shopId){
+		Shop shop = shopRepository.findById(shopId)
+			.orElseThrow(() -> new GeneralException(ErrorStatus.SHOP_NOT_FOUND));
+		return ShopDetailResponse.from(shop);
+
+	}
+
 }

--- a/src/main/java/com/roome/roome/be/domain/shop/service/ShopService.java
+++ b/src/main/java/com/roome/roome/be/domain/shop/service/ShopService.java
@@ -2,7 +2,10 @@ package com.roome.roome.be.domain.shop.service;
 
 import org.springframework.stereotype.Service;
 
+import com.roome.roome.be.common.exception.GeneralException;
+import com.roome.roome.be.common.status.ErrorStatus;
 import com.roome.roome.be.domain.shop.dto.request.ShopRegisterRequest;
+import com.roome.roome.be.domain.shop.dto.request.ShopUpdateRequest;
 import com.roome.roome.be.domain.shop.dto.response.ShopRegisterResponse;
 import com.roome.roome.be.domain.shop.entity.Shop;
 import com.roome.roome.be.domain.shop.repository.ShopRepository;
@@ -16,6 +19,7 @@ public class ShopService {
 
 	private final ShopRepository shopRepository;
 
+	//가게 등록
 	@Transactional
 	public ShopRegisterResponse registerShop(ShopRegisterRequest shopRegisterRequest) {
 		Shop shop = Shop.builder()
@@ -25,4 +29,16 @@ public class ShopService {
 		Shop savedShop = shopRepository.save(shop);
 		return ShopRegisterResponse.from(savedShop);
 	}
+
+	//가게 이름 수정
+	@Transactional
+	public void updateShop(Long shopId, ShopUpdateRequest shopUpdateRequest) {
+		Shop shop = shopRepository.findById(shopId)
+			.orElseThrow(() -> new GeneralException(ErrorStatus.SHOP_NOT_FOUND));
+
+		if (shopUpdateRequest.name() != null) {
+			shop.updateName(shopUpdateRequest.name());
+		}
+	}
+
 }

--- a/src/main/java/com/roome/roome/be/domain/user/entity/User.java
+++ b/src/main/java/com/roome/roome/be/domain/user/entity/User.java
@@ -36,7 +36,7 @@ public class User extends BaseEntity {
     private String refreshToken;
 
     @Enumerated(EnumType.STRING)
-    private Role role;  // ← 여기!
+    private Role role;
 
     public void updateRefreshToken(String refreshToken) {
         this.refreshToken = refreshToken;

--- a/src/main/java/com/roome/roome/be/domain/user/entity/User.java
+++ b/src/main/java/com/roome/roome/be/domain/user/entity/User.java
@@ -2,6 +2,8 @@ package com.roome.roome.be.domain.user.entity;
 
 import com.roome.roome.be.common.base.BaseEntity;
 import com.roome.roome.be.domain.user.enums.LoginType;
+import com.roome.roome.be.domain.user.enums.Role;
+
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -32,6 +34,9 @@ public class User extends BaseEntity {
     private String providerId;
 
     private String refreshToken;
+
+    @Enumerated(EnumType.STRING)
+    private Role role;  // ← 여기!
 
     public void updateRefreshToken(String refreshToken) {
         this.refreshToken = refreshToken;

--- a/src/main/java/com/roome/roome/be/domain/user/entity/User.java
+++ b/src/main/java/com/roome/roome/be/domain/user/entity/User.java
@@ -36,6 +36,7 @@ public class User extends BaseEntity {
     private String refreshToken;
 
     @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
     private Role role;
 
     public void updateRefreshToken(String refreshToken) {

--- a/src/main/java/com/roome/roome/be/domain/user/enums/Role.java
+++ b/src/main/java/com/roome/roome/be/domain/user/enums/Role.java
@@ -1,0 +1,13 @@
+package com.roome.roome.be.domain.user.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Role {
+	USER("일반 사용자"),
+	ADMIN("관리자");
+
+	private final String description;
+}

--- a/src/main/java/com/roome/roome/be/domain/user/service/GoogleService.java
+++ b/src/main/java/com/roome/roome/be/domain/user/service/GoogleService.java
@@ -4,6 +4,7 @@ import com.roome.roome.be.domain.user.dto.social.GoogleInfoDto;
 import com.roome.roome.be.domain.user.dto.social.GoogleTokenResponse;
 import com.roome.roome.be.domain.user.entity.User;
 import com.roome.roome.be.domain.user.enums.LoginType;
+import com.roome.roome.be.domain.user.enums.Role;
 import com.roome.roome.be.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -98,6 +99,7 @@ public class GoogleService {
                                 .nickname(googleInfo.getName())
                                 .email(googleInfo.getEmail())
                                 .loginType(LoginType.GOOGLE)
+                                .role(Role.USER)
                                 .build()
                 ));
     }

--- a/src/main/java/com/roome/roome/be/domain/user/service/KakaoService.java
+++ b/src/main/java/com/roome/roome/be/domain/user/service/KakaoService.java
@@ -4,6 +4,7 @@ import com.roome.roome.be.domain.user.dto.social.KakaoInfoDto;
 import com.roome.roome.be.domain.user.dto.social.KakaoTokenResponse;
 import com.roome.roome.be.domain.user.entity.User;
 import com.roome.roome.be.domain.user.enums.LoginType;
+import com.roome.roome.be.domain.user.enums.Role;
 import com.roome.roome.be.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -98,6 +99,7 @@ public class KakaoService {
                                 .nickname(kakaoInfo.getKakaoAccount().getProfile().getNickname())
                                 .email(kakaoInfo.getKakaoAccount().getEmail())
                                 .loginType(LoginType.KAKAO)
+                                .role(Role.USER)
                                 .build()
                 ));
     }

--- a/src/main/java/com/roome/roome/be/domain/user/service/UserService.java
+++ b/src/main/java/com/roome/roome/be/domain/user/service/UserService.java
@@ -9,6 +9,7 @@ import com.roome.roome.be.domain.user.dto.request.UserOnboardingRequest;
 import com.roome.roome.be.domain.user.entity.User;
 import com.roome.roome.be.domain.user.entity.UserOnboarding;
 import com.roome.roome.be.domain.user.enums.LoginType;
+import com.roome.roome.be.domain.user.enums.Role;
 import com.roome.roome.be.domain.user.repository.UserOnboardingRepository;
 import com.roome.roome.be.domain.user.repository.UserRepository;
 import io.jsonwebtoken.Claims;
@@ -87,6 +88,7 @@ public class UserService {
                 .nickname(request.nickname())
                 .phoneNumber(request.phoneNumber())
                 .loginType(LoginType.EMAIL)
+                .role(Role.USER)
                 .providerId(null)
                 .build();
         userRepository.save(user);


### PR DESCRIPTION
## #️⃣ 관련 이슈
closed #13 

## 💡 작업 배경
인테리어 Shop 관련 기능 구현했습니다.


## 🧩 작업 내용
- 일반 사용자, 관리자 Role 추가
- Role에 따른 페이지 접근 권한 수정
- 가게 등록(관리자)
- 가게 정보 수정(관리자)
- 가게 삭제(관리자)
- 가게 목록 구현(페이징, 키워드 검색)
- 가게 상세 정보 구현


## 📸 스크린샷(선택)
- Delete /admin/shop/{shopId} 가게 삭제
<img width="994" height="539" alt="Screenshot 2025-10-31 at 9 10 59 PM" src="https://github.com/user-attachments/assets/cb79986d-0d67-496d-9f17-dc924656e4c7" />

- Get /shop 가게 목록 조회(최근 등록된 가게부터 보여지게 역순으로 구현)
<img width="1461" height="550" alt="Screenshot 2025-10-31 at 9 05 38 PM" src="https://github.com/user-attachments/assets/dc5a9a94-e7ed-4b8a-93fc-470644d715e6" />
<img width="1410" height="496" alt="Screenshot 2025-10-31 at 9 05 50 PM" src="https://github.com/user-attachments/assets/f482768d-da46-4e81-a2b3-6badbff3bac4" />


- Get /shop/{shopId} 가게 상세 조회
<img width="1290" height="777" alt="Screenshot 2025-10-31 at 9 06 41 PM" src="https://github.com/user-attachments/assets/739fa036-a0fb-4392-8de4-b70ef1c3c482" />

- Patch /admin/shop/{shopId} 가게 정보 수정
<img width="984" height="817" alt="Screenshot 2025-10-31 at 9 10 44 PM" src="https://github.com/user-attachments/assets/86055247-d633-4099-adb6-8053732198a4" />

- Post /admin/shop 가게 정보 입력
<img width="985" height="807" alt="Screenshot 2025-10-31 at 9 10 24 PM" src="https://github.com/user-attachments/assets/bad1f55c-960e-42b4-a10b-4fb54f034ee6" />


## 📝 기타
가게 관련 엔티티에 필요한 추가적인 정보는 추후 디자인이 나오면 더 필요한 것이 있으면 추가해야할 것 같습니다. 일단은 가게 이름만 저장하였습니다. 

