### PR TITLE
[Refactor/Feat] 가구 필터링 세분화, queryDSL로 확장

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,12 @@ dependencies {
 
     //S3
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
+    //QueryDSL
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {

--- a/src/main/java/com/roome/roome/be/common/config/QueryDslConfig.java
+++ b/src/main/java/com/roome/roome/be/common/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package com.roome.roome.be.common.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/roome/roome/be/common/config/SecurityConfig.java
+++ b/src/main/java/com/roome/roome/be/common/config/SecurityConfig.java
@@ -63,7 +63,7 @@ public class SecurityConfig {
                         .requestMatchers(SWAGGER_URIS).permitAll()
                         .requestMatchers(AUTH_URIS).permitAll()
                         .requestMatchers(ACTUATOR_URIS).permitAll()
-                        .requestMatchers("/api/auth/**").permitAll() // 혹시 빠진 URI 커버
+                        .requestMatchers("/api/auth/**").permitAll()
                         .requestMatchers("/admin/**").hasRole("ADMIN")
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/roome/roome/be/common/s3/service/ImageUrlBuilder.java
+++ b/src/main/java/com/roome/roome/be/common/s3/service/ImageUrlBuilder.java
@@ -10,7 +10,9 @@ public class ImageUrlBuilder {
 
 	public String build(String objectKey) {
 		if (objectKey == null || objectKey.isBlank()) return null;
-
+		if (objectKey.startsWith("http")) {
+			return objectKey;
+		}
 		String base = cdnBaseUrl.endsWith("/") ? cdnBaseUrl : cdnBaseUrl + "/";
 		String key  = objectKey.startsWith("/") ? objectKey.substring(1) : objectKey;
 		return base + key;

--- a/src/main/java/com/roome/roome/be/domain/product/controller/ProductController.java
+++ b/src/main/java/com/roome/roome/be/domain/product/controller/ProductController.java
@@ -51,51 +51,76 @@ public class ProductController {
 	//상품 목록
 	@GetMapping
 	@Operation(
-		summary = "상품 목록 조회",
-		description = """
-카테고리, 색상, 가게, 검색어, 가격범위로 필터링하고 정렬·페이지네이션을 적용하여 상품 목록을 조회합니다.
+			summary = "상품 목록 조회",
+			description = """
+상품의 카테고리, 태그(색상, 소재 등), 가게, 검색어, 가격범위로 필터링하고 정렬·페이지네이션을 적용하여 상품 목록을 조회합니다.
 
 [필터]
 - category: 상품 카테고리 (예: FURNITURE, BEDDING ...)
-- color: 색상 태그. 다중 지정 가능 (예: color=WHITE&color=GREEN)
-- match: 색상 매칭 방식 (any | all). 기본값 any
 - shopId: 특정 가게의 상품만 조회
 - keyWord: **상품명(name)** 에서만 부분 일치 검색
 - minPrice, maxPrice: 가격 범위 필터
+- **tags: color, material, style, feature, mood (다중 지정 가능)**
+- **match: 태그 매칭 방식 (any | all). 기본값 any**
 
 [정렬 가능 필드]
 - id, price, createdAt, popularity (있다면)
 
 [예시]
-- /api/products?category=FURNITURE&color=WHITE&color=GREEN&match=any&sort=price,asc&page=0&size=20
-- /api/products?shopId=12&q=의자&minPrice=20000&maxPrice=70000&color=BEIGE&color=BROWN&match=all&sort=createdAt,desc
+- **(신규)** /api/products?category=DININGROOM_CHAIR&color=WHITE&material=WOOD&match=all
+- **(수정)** /api/products?shopId=12&keyWord=의자&minPrice=20000&maxPrice=70000
 - /api/products?sort=popularity,desc
 """
 	)
 	@Parameters({
-		@Parameter(name = "shopId", description = "가게 ID. 지정 시 해당 가게의 상품만 조회", example = "12"),
-		@Parameter(name = "category", description = "상품 카테고리"),
-		@Parameter(
-			name = "color",
-			description = "색상 태그(다중 지정 가능). 예: color=WHITE&color=GREEN",
-			array = @ArraySchema(schema = @Schema(type = "string"))
-		),
-		@Parameter(
-			name = "match",
-			description = "색상 매칭 방식(any: 하나라도 일치, all: 전부 일치)",
-			schema = @Schema(allowableValues = {"any", "all"}, defaultValue = "any")
-		),
-		@Parameter(name = "keyWord", description = "상품명(name)에서 부분 일치 검색", example = "의자"),
-		@Parameter(name = "minPrice", description = "최소 가격", example = "10000"),
-		@Parameter(name = "maxPrice", description = "최대 가격", example = "50000"),
-		@Parameter(name = "sort", description = "정렬 (예: price,asc | createdAt,desc"),
-		@Parameter(name = "page", description = "페이지 번호", example = "0"),
-		@Parameter(name = "size", description = "페이지 크기", example = "20")
+			@Parameter(name = "shopId", description = "가게 ID. 지정 시 해당 가게의 상품만 조회", example = "1"),
+			@Parameter(name = "category", description = "상품 카테고리"),
+			@Parameter(name = "keyWord", description = "상품명(name)에서 부분 일치 검색", example = "테이블"),
+			@Parameter(name = "minPrice", description = "최소 가격", example = "10000"),
+			@Parameter(name = "maxPrice", description = "최대 가격", example = "100000"),
+
+			@Parameter(
+					name = "color",
+					description = "색상 태그(다중 지정 가능). 예: color=WHITE&color=GREEN",
+					array = @ArraySchema(schema = @Schema(type = "string"))
+			),
+			@Parameter(
+					name = "material",
+					description = "소재 태그(다중 지정 가능) 예: material=WOOD" ,
+					array = @ArraySchema(schema = @Schema(type = "string"))
+			),
+			@Parameter(
+					name = "style",
+					description = "스타일 태그(다중 지정 가능) 예: style=MODERN",
+					array = @ArraySchema(schema = @Schema(type = "string"))
+			),
+			@Parameter(
+					name = "feature",
+					description = "기능 태그(다중 지정 가능) 예: feature=WATERPROOF",
+					array = @ArraySchema(schema = @Schema(type = "string"))
+			),
+			@Parameter(
+					name = "mood",
+					description = "무드 태그(다중 지정 가능) 예: mood=DECORATIVE",
+					array = @ArraySchema(schema = @Schema(type = "string"))
+			),
+			@Parameter(
+					name = "match",
+					description = "태그 매칭 방식(any: 하나라도 일치, all: 전부 일치)",
+					schema = @Schema(allowableValues = {"any", "all"}, defaultValue = "any")
+			),
+			@Parameter(name = "sort", description = "정렬 (예: price,asc | createdAt,desc"),
+			@Parameter(name = "page", description = "페이지 번호", example = "0"),
+			@Parameter(name = "size", description = "페이지 크기", example = "20")
 	})
 	public ResponseEntity<ApiResponse<Page<ProductListItemResponse>>> getProducts(
 		@RequestParam(required = false) Long shopId,
 		@RequestParam(required = false) Category category,
-		@RequestParam(required = false, name = "color") List<String> colorNames,
+		@RequestParam(required = false, name = "color") List<String> colorTags,
+        @RequestParam(required = false, name = "material") List<String> materialTags,
+		@RequestParam(required = false, name = "style") List<String> styleTags,
+		@RequestParam(required = false, name = "feature") List<String> featureTags,
+		@RequestParam(required = false, name = "mood") List<String> moodTags,
 		@RequestParam(required = false, defaultValue = "any") String match,
 		@RequestParam(required = false) String keyWord,
 		@RequestParam(required = false) Integer minPrice,
@@ -103,7 +128,7 @@ public class ProductController {
 		@ParameterObject
 		@PageableDefault(size = 20, sort = "id", direction = Sort.Direction.DESC) Pageable pageable
 	) {
-		var page = productService.getList(shopId, category, colorNames, match, keyWord, minPrice, maxPrice, pageable);
+		var page = productService.getList(shopId, category, colorTags, materialTags, styleTags, featureTags, moodTags, match, keyWord, minPrice, maxPrice, pageable);
 		return ApiResponse.success(SuccessStatus.GET_PRODUCT_LIST, page);
 	}
 }

--- a/src/main/java/com/roome/roome/be/domain/product/enums/Color.java
+++ b/src/main/java/com/roome/roome/be/domain/product/enums/Color.java
@@ -25,7 +25,8 @@ public enum Color {
 	PURPLE("퍼플"),
 	GOLD("골드"),
 	SILVER("실버"),
-	TRANSPARENT("투명");
+	TRANSPARENT("투명"),
+	MULTICOLOR("여러 색");
 
 	private final String description;
 }

--- a/src/main/java/com/roome/roome/be/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/roome/roome/be/domain/product/repository/ProductRepository.java
@@ -1,85 +1,13 @@
 package com.roome.roome.be.domain.product.repository;
 
-import java.util.List;
 import java.util.Optional;
 
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
-
 import com.roome.roome.be.domain.product.entity.Product;
-import com.roome.roome.be.domain.product.enums.Category;
 
-public interface ProductRepository extends JpaRepository<Product, Long> {
+public interface ProductRepository extends JpaRepository<Product, Long>, ProductRepositoryCustom {
 
 	@EntityGraph(attributePaths = {"shop"})
 	Optional<Product> findById(Long id);
-
-
-	// 색상 any 옵션
-	@EntityGraph(attributePaths = {"shop"})
-	@Query("""
-SELECT DISTINCT p
-FROM Product p
-LEFT JOIN p.shop s
-LEFT JOIN p.productTags pt
-LEFT JOIN pt.tag t
-WHERE (:shopId IS NULL OR s.id = :shopId)
-  AND (:category IS NULL OR p.category = :category)
-  AND (:q IS NULL OR p.name LIKE CONCAT('%', :q, '%'))
-  AND (:minPrice IS NULL OR p.price >= :minPrice)
-  AND (:maxPrice IS NULL OR p.price <= :maxPrice)
-  AND (
-        :hasColor = false
-        OR (t.type = com.roome.roome.be.domain.product.enums.TagType.COLOR AND t.name IN :colorNames)
-      )
-""")
-	Page<Product> findByFiltersAnyColors(@Param("shopId") Long shopId,
-		@Param("category") Category category,
-		@Param("q") String q,
-		@Param("minPrice") Integer minPrice,
-		@Param("maxPrice") Integer maxPrice,
-		@Param("hasColor") boolean hasColor,
-		@Param("colorNames") List<String> colorNames,
-		Pageable pageable);
-
-//색상 all 옵션
-	@EntityGraph(attributePaths = {"shop"})
-	@Query("""
-SELECT p
-FROM Product p
-JOIN p.shop s
-LEFT JOIN p.productTags pt
-LEFT JOIN pt.tag t
-WHERE (:shopId IS NULL OR s.id = :shopId)
-  AND (:category IS NULL OR p.category = :category)
-  AND (:q IS NULL OR p.name LIKE CONCAT('%', :q, '%'))
-  AND (:minPrice IS NULL OR p.price >= :minPrice)
-  AND (:maxPrice IS NULL OR p.price <= :maxPrice)
-  AND (
-        :hasColor = false
-        OR p.id IN (
-            SELECT pt2.product.id
-            FROM ProductTag pt2
-            JOIN pt2.tag t2
-            WHERE t2.type = com.roome.roome.be.domain.product.enums.TagType.COLOR
-              AND t2.name IN :colorNames
-            GROUP BY pt2.product.id
-            HAVING COUNT(DISTINCT t2.name) = :size
-        )
-      )
-GROUP BY p.id
-""")
-	Page<Product> findByFiltersAllColors(@Param("shopId") Long shopId,
-		@Param("category") Category category,
-		@Param("q") String q,
-		@Param("minPrice") Integer minPrice,
-		@Param("maxPrice") Integer maxPrice,
-		@Param("hasColor") boolean hasColor,
-		@Param("colorNames") List<String> colorNames,
-		@Param("size") long size,
-		Pageable pageable);
 }

--- a/src/main/java/com/roome/roome/be/domain/product/repository/ProductRepositoryCustom.java
+++ b/src/main/java/com/roome/roome/be/domain/product/repository/ProductRepositoryCustom.java
@@ -1,0 +1,33 @@
+package com.roome.roome.be.domain.product.repository;
+
+import com.roome.roome.be.domain.product.entity.Product;
+import com.roome.roome.be.domain.product.enums.Category;
+import com.roome.roome.be.domain.product.enums.TagType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * QueryDSL을 사용한 동적 쿼리 인터페이스
+ */
+public interface ProductRepositoryCustom {
+
+    /**
+     * 상품 목록을 동적 필터(태그 포함)로 조회합니다.
+     *
+     * @param tagFilters (예: {TagType.COLOR: ["WHITE", "BLUE"], TagType.MATERIAL: ["WOOD"]})
+     * @param match      (any: OR 조건, all: AND 조건)
+     */
+    Page<Product> findByDynamicFilters(
+            Long shopId,
+            Category category,
+            String keyWord,
+            Integer minPrice,
+            Integer maxPrice,
+            Map<TagType, List<String>> tagFilters,
+            String match,
+            Pageable pageable
+    );
+}

--- a/src/main/java/com/roome/roome/be/domain/product/repository/ProductRepositoryImpl.java
+++ b/src/main/java/com/roome/roome/be/domain/product/repository/ProductRepositoryImpl.java
@@ -1,0 +1,154 @@
+package com.roome.roome.be.domain.product.repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.roome.roome.be.domain.product.entity.Product;
+import com.roome.roome.be.domain.product.enums.Category;
+import com.roome.roome.be.domain.product.enums.TagType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.roome.roome.be.domain.product.entity.QProduct.product;
+import static com.roome.roome.be.domain.product.entity.QProductTag.productTag;
+import static com.roome.roome.be.domain.product.entity.QTag.tag;
+import static com.roome.roome.be.domain.shop.entity.QShop.shop;
+
+@RequiredArgsConstructor
+public class ProductRepositoryImpl implements ProductRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory; // QueryDSL 사용을 위해 주입
+
+    @Override
+    public Page<Product> findByDynamicFilters(
+            Long shopId,
+            Category category,
+            String keyWord,
+            Integer minPrice,
+            Integer maxPrice,
+            Map<TagType, List<String>> tagFilters,
+            String match,
+            Pageable pageable
+    ) {
+
+        // 1. 기본 쿼리 (SELECT p FROM Product p ...)
+        JPAQuery<Product> query = queryFactory
+                .selectFrom(product)
+                .leftJoin(product.shop, shop).fetchJoin() // N+1 방지
+                .distinct();
+
+        // 2. 동적 WHERE 조건 조립
+        query.where(
+                shopIdEq(shopId),
+                categoryEq(category),
+                nameContains(keyWord),
+                priceGoe(minPrice),
+                priceLoe(maxPrice),
+                tagFilter(tagFilters, match) // ★ 모든 태그 필터를 이 메서드가 처리
+        );
+
+        // 3. 페이징 및 정렬 적용
+        query
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize());
+
+        // 4. 쿼리 실행 (Content)
+        List<Product> content = query.fetch();
+
+        // 5. Count 쿼리 실행 (페이징을 위해)
+        JPAQuery<Long> countQuery = queryFactory
+                .select(product.countDistinct())
+                .from(product)
+                .where(
+                        shopIdEq(shopId),
+                        categoryEq(category),
+                        nameContains(keyWord),
+                        priceGoe(minPrice),
+                        priceLoe(maxPrice),
+                        tagFilter(tagFilters, match)
+                );
+
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+    }
+
+    private BooleanExpression shopIdEq(Long shopId) {
+        return shopId != null ? product.shop.id.eq(shopId) : null;
+    }
+
+    private BooleanExpression categoryEq(Category category) {
+        return category != null ? product.category.eq(category) : null;
+    }
+
+    private BooleanExpression nameContains(String keyWord) {
+        return keyWord != null && !keyWord.isBlank() ? product.name.containsIgnoreCase(keyWord) : null;
+    }
+
+    private BooleanExpression priceGoe(Integer minPrice) {
+        return minPrice != null ? product.price.goe(minPrice) : null;
+    }
+
+    private BooleanExpression priceLoe(Integer maxPrice) {
+        return maxPrice != null ? product.price.loe(maxPrice) : null;
+    }
+
+    // ★★★ 태그 동적 처리 (핵심) ★★★
+    private BooleanExpression tagFilter(Map<TagType, List<String>> tagFilters, String match) {
+        if (tagFilters == null || tagFilters.isEmpty()) {
+            return null; // 태그 필터 없으면 null 반환
+        }
+
+        // 'match=all' (모든 조건 AND)
+        // (예: COLOR=[WHITE], MATERIAL=[WOOD] -> (WHITE) AND (WOOD)를 가진 상품)
+        if ("all".equalsIgnoreCase(match)) {
+            BooleanExpression allMatch = null;
+            for (Map.Entry<TagType, List<String>> entry : tagFilters.entrySet()) {
+                TagType type = entry.getKey();
+                List<String> names = entry.getValue();
+
+                if (names != null && !names.isEmpty()) {
+                    BooleanExpression subQuery = product.id.in(
+                            JPAExpressions.select(productTag.product.id)
+                                    .from(productTag)
+                                    .join(productTag.tag, tag)
+                                    .where(
+                                            tag.type.eq(type),
+                                            tag.name.in(names)
+                                    )
+                                    .groupBy(productTag.product.id)
+                                    .having(tag.name.countDistinct().eq((long) names.size())) // all
+                    );
+                    allMatch = (allMatch == null) ? subQuery : allMatch.and(subQuery);
+                }
+            }
+            return allMatch;
+        }
+
+        else {
+            BooleanExpression anyMatch = null;
+            for (Map.Entry<TagType, List<String>> entry : tagFilters.entrySet()) {
+                TagType type = entry.getKey();
+                List<String> names = entry.getValue();
+
+                if (names != null && !names.isEmpty()) {
+                    BooleanExpression condition = JPAExpressions
+                            .selectOne()
+                            .from(productTag)
+                            .join(productTag.tag, tag)
+                            .where(
+                                    productTag.product.eq(product), // Correlated subquery
+                                    tag.type.eq(type),
+                                    tag.name.in(names)
+                            ).exists();
+                    anyMatch = (anyMatch == null) ? condition : anyMatch.or(condition);
+                }
+            }
+            return anyMatch;
+        }
+    }
+}

--- a/src/main/java/com/roome/roome/be/domain/product/service/ProductService.java
+++ b/src/main/java/com/roome/roome/be/domain/product/service/ProductService.java
@@ -1,7 +1,10 @@
 package com.roome.roome.be.domain.product.service;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
+import com.roome.roome.be.domain.product.enums.TagType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -110,33 +113,43 @@ public class ProductService {
 	// 목록 조회
 	@Transactional(readOnly = true)
 	public Page<ProductListItemResponse> getList(
-		Long shopId,                 // 가게 필터
-		Category category,
-		List<String> colorNames,
-		String match,                // 기본 any
-		String keyWord,
-		Integer minPrice,
-		Integer maxPrice,
-		Pageable pageable
+			Long shopId,                 // 가게 필터
+			Category category,
+			List<String> colorTags,
+			List<String> materialTags,
+			List<String> styleTags,
+			List<String> featureTags,
+			List<String> moodTags,
+			String match,                // 기본 any
+			String keyWord,
+			Integer minPrice,
+			Integer maxPrice,
+			Pageable pageable
 	) {
-		final boolean hasColor = colorNames != null && !colorNames.isEmpty();
+		// [수정 3] match 문자열 정규화
 		final String normalizedMatch = (match == null) ? "any" : match.trim().toLowerCase();
 
-		Page<Product> page;
-		if ("all".equals(normalizedMatch)) {
-			long size = hasColor ? colorNames.size() : 0;
-			page = productRepository.findByFiltersAllColors(
-				shopId, category, keyWord, minPrice, maxPrice,
-				hasColor, colorNames, size, pageable
-			);
-		} else {
-			page = productRepository.findByFiltersAnyColors(
-				shopId, category, keyWord, minPrice, maxPrice,
-				hasColor, colorNames, pageable
-			);
-		}
+		// [수정 4] 모든 태그 파라미터를 Map으로 조립
+		Map<TagType, List<String>> tagFilters = new HashMap<>();
+		if (colorTags != null && !colorTags.isEmpty()) tagFilters.put(TagType.COLOR, colorTags);
+		if (materialTags != null && !materialTags.isEmpty()) tagFilters.put(TagType.MATERIAL, materialTags);
+		if (styleTags != null && !styleTags.isEmpty()) tagFilters.put(TagType.STYLE, styleTags);
+		if (featureTags != null && !featureTags.isEmpty()) tagFilters.put(TagType.FEATURE, featureTags);
+		if (moodTags != null && !moodTags.isEmpty()) tagFilters.put(TagType.MOOD, moodTags);
+
+		Page<Product> page = productRepository.findByDynamicFilters(
+				shopId,
+				category,
+				keyWord,
+				minPrice,
+				maxPrice,
+				tagFilters,
+				normalizedMatch,
+				pageable
+		);
 
 		return page.map(p -> ProductListItemResponse.from(p, imageUrlBuilder));
+
 	}
 
 	// 상품 수정

--- a/src/main/java/com/roome/roome/be/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/roome/roome/be/domain/user/repository/UserRepository.java
@@ -7,7 +7,6 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {


### PR DESCRIPTION
## #️⃣ 관련 이슈
closed #27 

## 💡 작업 배경
기존 상품 목록 조회 로직은 단순히 색상(color) 태그만을 기준으로 필터링
-> 상품 태그를 색상, 스타일, 소재, 시즌 등 다양한 유형으로 세분화하게 되면서 QueryDSL를 도입하여 동적 쿼리 구조로 개선했습니다.

## 🧩 작업 내용
QueryDSL을 사용한 상품 동적 필터링 구현
상품 목록 다중 태그 필터링 기능 추가


## 📸 스크린샷(선택)
<img width="1024" height="294" alt="image" src="https://github.com/user-attachments/assets/bc084560-e864-45d5-9c32-7bf91c20765c" />

<img width="2048" height="1141" alt="image" src="https://github.com/user-attachments/assets/5e6480e7-ae2e-4ab9-ac71-2e088c185fe7" />

<img width="2048" height="1046" alt="image" src="https://github.com/user-attachments/assets/e6b6b3ff-818a-4b35-a8d9-b05c37ee806f" />


## 📝 기타
