### PR TITLE
[Feat] 가게(Shop)에 로고 이미지 추가

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -96,12 +96,18 @@ jobs:
             EMAIL_PASSWORD=${{ secrets.EMAIL_PASSWORD }}
             EMAIL_SENDER_ADDRESS=${{ secrets.EMAIL_SENDER_ADDRESS }}
             EMAIL_USERNAME=${{ secrets.EMAIL_USERNAME }}
-            S3_ACCESS_KEY=${{secrets.S3_ACCESS_KEY}}
-            S3_SECRET_KEY=${{secrets.S3_SECRET_KEY}}
-            S3_BUCKET_NAME=${{secrets.S3_BUCKET_NAME}}
-            S3_REGION=${{secrets.S3_REGION}}
-            EOF
             
+            CLOUD_AWS_CREDENTIALS_ACCESS_KEY=${{secrets.S3_ACCESS_KEY}}
+            CLOUD_AWS_CREDENTIALS_SECRET_KEY=${{secrets.S3_SECRET_KEY}}
+            CLOUD_AWS_S3_BUCKET=${{secrets.S3_BUCKET_NAME}}
+            CLOUD_AWS_REGION_STATIC=${{secrets.S3_REGION}}
+            
+            CDN_BASE_URL=${{ secrets.CDN_BASE_URL }}
+            SHOP_LOGO=${{ secrets.SHOP_LOGO }}
+            STORAGE_CDN_BASE_URL=${{ secrets.CDN_BASE_URL }}
+            
+            EOF
+         
             sudo chmod +x deploy.sh
             sudo ./deploy.sh
             sudo docker image prune -af

--- a/src/main/java/com/roome/roome/be/common/s3/controller/S3Controller.java
+++ b/src/main/java/com/roome/roome/be/common/s3/controller/S3Controller.java
@@ -46,7 +46,7 @@ public class S3Controller {
 	}
 
 	//샵로고 등록 전 사진 임시저장을 위한 api
-	@PostMapping("/admin/uploads/{sessionId}/shops/logo/presigned")
+	@PostMapping("/uploads/{sessionId}/shops/logo/presigned")
 	public ResponseEntity<ApiResponse<PresignedUrlResponse>> presignedShopLogo(
 		@PathVariable long sessionId,
 		@RequestBody PresignedUrlRequest presignedUrlRequest

--- a/src/main/java/com/roome/roome/be/common/s3/controller/S3Controller.java
+++ b/src/main/java/com/roome/roome/be/common/s3/controller/S3Controller.java
@@ -21,6 +21,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -38,10 +39,21 @@ public class S3Controller {
 	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "관리자 권한이 없는 경우", content = @Content)
 	public ResponseEntity<ApiResponse<List<PresignedUrlBatchResponse>>> generatePresignedUrls(
 		@PathVariable Long sessionId,
-		@RequestBody List<PresignedUrlRequest> files
+		@RequestBody List<PresignedUrlRequest> presignedUrlRequests
 	) {
-		var responses = s3Service.generatePresignedPutUrls(StorageScope.PRODUCT_DETAIL, sessionId, files);
+		var responses = s3Service.generatePresignedPutUrls(StorageScope.PRODUCT_DETAIL, sessionId, presignedUrlRequests);
 		return ApiResponse.success(SuccessStatus.S3_PRESIGNED_ISSUE_SUCCESS, responses);
 	}
 
+	//샵로고 등록 전 사진 임시저장을 위한 api
+	@PostMapping("/admin/uploads/{sessionId}/shops/logo/presigned")
+	public ResponseEntity<ApiResponse<PresignedUrlResponse>> presignedShopLogo(
+		@PathVariable long sessionId,
+		@RequestBody PresignedUrlRequest presignedUrlRequest
+	) {
+		var response = s3Service.generatePresignedPutUrl(
+			StorageScope.SHOP_PROFILE, sessionId, presignedUrlRequest
+		);
+		return ApiResponse.success(SuccessStatus.S3_PRESIGNED_ISSUE_SUCCESS, response);
+	}
 }

--- a/src/main/java/com/roome/roome/be/common/s3/dto/request/PresignedUrlRequest.java
+++ b/src/main/java/com/roome/roome/be/common/s3/dto/request/PresignedUrlRequest.java
@@ -2,6 +2,7 @@ package com.roome.roome.be.common.s3.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 @Schema(description = "Presigned URL 발급 요청 파일 정보")
 public record PresignedUrlRequest(
@@ -10,10 +11,10 @@ public record PresignedUrlRequest(
 	String contentType,
 
 	@Schema(description = "파일 크기(Byte)", example = "1048576")
-	@NotBlank(message = "sizeBytes은 필수입니다.")
+	@NotNull(message = "sizeBytes은 필수입니다.")
 	long sizeBytes,
 
 	@Schema(description = "이미지 순서 (여러 장 업로드 시 정렬용)", example = "1")
-	@NotBlank(message = "order는 필수입니다.")
+	@NotNull(message = "order는 필수입니다.")
 	Integer order
 ) {}

--- a/src/main/java/com/roome/roome/be/common/s3/service/S3Service.java
+++ b/src/main/java/com/roome/roome/be/common/s3/service/S3Service.java
@@ -1,11 +1,20 @@
 package com.roome.roome.be.common.s3.service;
 
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.amazonaws.HttpMethod;
 import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.model.DeleteObjectsRequest;
 import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
-import com.amazonaws.services.s3.model.ListObjectsV2Request;
-import com.amazonaws.services.s3.model.ListObjectsV2Result;
 import com.roome.roome.be.common.exception.GeneralException;
 import com.roome.roome.be.common.s3.dto.request.PresignedUrlRequest;
 import com.roome.roome.be.common.s3.dto.response.PresignedUrlBatchResponse;
@@ -14,12 +23,6 @@ import com.roome.roome.be.common.s3.enums.StorageScope;
 import com.roome.roome.be.common.status.ErrorStatus;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.net.URL;
-import java.util.*;
 
 @Service
 @RequiredArgsConstructor
@@ -38,19 +41,19 @@ public class S3Service {
 	private static final long MAX_SIZE = 5 * 1024 * 1024; // 5MB
 	private static final long DEFAULT_EXPIRE_MILLIS = 5 * 60_000L; // 5분
 
-	public PresignedUrlResponse generatePresignedPutUrl(StorageScope storageScope, long productId, PresignedUrlRequest presignedUrlRequest) {
+
+	public PresignedUrlResponse generatePresignedPutUrl(StorageScope storageScope, long id, PresignedUrlRequest presignedUrlRequest) {
 		validate(presignedUrlRequest.contentType(), presignedUrlRequest.sizeBytes());
 		String ext = CT_TO_EXT.get(presignedUrlRequest.contentType());
-		String key = buildKey(storageScope, productId, ext);
-
+		String key = buildKey(storageScope, id, ext);
 		URL url = generatePutUrl(key, presignedUrlRequest.contentType(), DEFAULT_EXPIRE_MILLIS);
 		return new PresignedUrlResponse(url.toString(), key);
 	}
 
-	public List<PresignedUrlBatchResponse> generatePresignedPutUrls(StorageScope storageScope, long productId, List<PresignedUrlRequest> presignedUrlRequests) {
+	public List<PresignedUrlBatchResponse> generatePresignedPutUrls(StorageScope storageScope, long id, List<PresignedUrlRequest> presignedUrlRequests) {
 		List<PresignedUrlBatchResponse> list = new ArrayList<>();
 		for (PresignedUrlRequest presignedUrlRequest : presignedUrlRequests) {
-			PresignedUrlResponse presignedUrlResponse = generatePresignedPutUrl(storageScope, productId, presignedUrlRequest);
+			PresignedUrlResponse presignedUrlResponse = generatePresignedPutUrl(storageScope, id, presignedUrlRequest);
 			list.add(new PresignedUrlBatchResponse(presignedUrlResponse.uploadUrl(), presignedUrlResponse.objectKey(), presignedUrlRequest.order()));
 		}
 		return list;
@@ -69,12 +72,12 @@ public class S3Service {
 		if (sizeBytes > MAX_SIZE) throw new GeneralException(ErrorStatus.FILE_TOO_LARGE);
 	}
 
-	private String buildKey(StorageScope storageScope, long productID, String ext) {
+	private String buildKey(StorageScope storageScope, long id, String ext) {
 		String uuid = UUID.randomUUID().toString();
 		return switch (storageScope) {
-			case SHOP_PROFILE   -> "shops/%d/profile/%s.%s".formatted(productID, uuid, ext);
-			case PRODUCT_DETAIL -> "products/%d/detail/%s.%s".formatted(productID, uuid, ext);
-			case UPLOAD_SESSION -> "uploads/%d/detail/%s.%s".formatted(productID, uuid, ext);
+			case SHOP_PROFILE   -> "shops/%d/profile/%s.%s".formatted(id, uuid, ext);
+			case PRODUCT_DETAIL -> "products/%d/detail/%s.%s".formatted(id, uuid, ext);
+			case UPLOAD_SESSION -> "uploads/%d/detail/%s.%s".formatted(id, uuid, ext);
 		};
 	}
 

--- a/src/main/java/com/roome/roome/be/domain/product/controller/AdminProductController.java
+++ b/src/main/java/com/roome/roome/be/domain/product/controller/AdminProductController.java
@@ -42,7 +42,7 @@ public class AdminProductController {
 	}
 
 	// 상품 수정
-	@PatchMapping("/admin/products/{productId}")
+	@PatchMapping("/products/{productId}")
 	@Operation(summary = "상품 수정(통합)", description = "기본정보/태그/이미지를 한 번에 부분 수정합니다. images가 전달되면 전체 교체됩니다.")
 	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "상품 수정 성공", content = @Content)
 	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "상품/샵이 존재하지 않음", content = @Content)
@@ -55,7 +55,7 @@ public class AdminProductController {
 	}
 
 	//상품 이미지 교체
-	@PatchMapping("/admin/products/{productId}/images")
+	@PatchMapping("/products/{productId}/images")
 	@Operation(
 		summary = "상품 이미지 전체 교체",
 		description = """
@@ -77,7 +77,7 @@ public class AdminProductController {
 	}
 
 	//상품 삭제
-	@DeleteMapping("/admin/products/{productId}")
+	@DeleteMapping("/products/{productId}")
 	@Operation(
 		summary = "상품 삭제(관리자)",
 		description = "연관된 이미지/태그를 정리한 뒤 상품을 삭제합니다."

--- a/src/main/java/com/roome/roome/be/domain/product/service/ProductService.java
+++ b/src/main/java/com/roome/roome/be/domain/product/service/ProductService.java
@@ -2,6 +2,7 @@ package com.roome.roome.be.domain.product.service;
 
 import java.util.List;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -45,6 +46,9 @@ public class ProductService {
 	private final ProductImageService productImageService;
 	private final S3Service s3Service;
 	private final ImageUrlBuilder imageUrlBuilder;
+
+	@Value("${storage.defaults.shop-logo}")
+	private String defaultShopLogoUrl;
 
 	// 상품 등록
 	@Transactional
@@ -91,7 +95,11 @@ public class ProductService {
 				productTag.getTag().getName()))
 			.toList();
 
-		var shop = new ShopSummaryResponse(product.getShop().getId(), product.getShop().getName());
+		String logoUrl = (product.getShop().getLogoObjectKey() != null && !product.getShop().getLogoObjectKey().isBlank())
+			? imageUrlBuilder.build(product.getShop().getLogoObjectKey())
+			: defaultShopLogoUrl;
+
+		var shop = ShopSummaryResponse.from(product.getShop(), logoUrl);
 
 		return new ProductDetailResponse(
 			product.getId(),

--- a/src/main/java/com/roome/roome/be/domain/shop/controller/AdminShopController.java
+++ b/src/main/java/com/roome/roome/be/domain/shop/controller/AdminShopController.java
@@ -47,7 +47,7 @@ public class AdminShopController {
 	@PatchMapping("/{shopId}")
 	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "가게 수정 성공", content = @Content)
 	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "가게가 존재하지 않는 경우", content = @Content)
-	@Operation(summary = "가게 이름 수정 (관리자)")
+	@Operation(summary = "가게 수정 (관리자)")
 	public ResponseEntity<ApiResponse<Void>> updateShop(
 		@PathVariable Long shopId,
 		@RequestBody ShopUpdateRequest shopUpdateRequest

--- a/src/main/java/com/roome/roome/be/domain/shop/dto/request/ShopRegisterRequest.java
+++ b/src/main/java/com/roome/roome/be/domain/shop/dto/request/ShopRegisterRequest.java
@@ -4,5 +4,14 @@ import jakarta.validation.constraints.NotBlank;
 
 public record ShopRegisterRequest (
 	@NotBlank(message = "가게 이름은 필수입니다.")
-	String name
-){}
+	String name,
+
+	ShopLogoRequest logo
+
+) {
+
+	public record ShopLogoRequest(
+		@NotBlank(message = "로고 objectKey는 필수입니다.")
+		String objectKey
+	) {}
+}

--- a/src/main/java/com/roome/roome/be/domain/shop/dto/request/ShopRegisterRequest.java
+++ b/src/main/java/com/roome/roome/be/domain/shop/dto/request/ShopRegisterRequest.java
@@ -6,12 +6,7 @@ public record ShopRegisterRequest (
 	@NotBlank(message = "가게 이름은 필수입니다.")
 	String name,
 
-	ShopLogoRequest logo
+	@NotBlank(message = "로고 objectKey는 필수입니다.")
+	String logoObjectKey
 
-) {
-
-	public record ShopLogoRequest(
-		@NotBlank(message = "로고 objectKey는 필수입니다.")
-		String objectKey
-	) {}
-}
+) { }

--- a/src/main/java/com/roome/roome/be/domain/shop/dto/request/ShopUpdateRequest.java
+++ b/src/main/java/com/roome/roome/be/domain/shop/dto/request/ShopUpdateRequest.java
@@ -1,5 +1,6 @@
 package com.roome.roome.be.domain.shop.dto.request;
 
 public record ShopUpdateRequest(
-	String name
+	String name,
+	ShopRegisterRequest.ShopLogoRequest logo
 ){}

--- a/src/main/java/com/roome/roome/be/domain/shop/dto/request/ShopUpdateRequest.java
+++ b/src/main/java/com/roome/roome/be/domain/shop/dto/request/ShopUpdateRequest.java
@@ -1,6 +1,8 @@
 package com.roome.roome.be.domain.shop.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
+
 public record ShopUpdateRequest(
 	String name,
-	ShopRegisterRequest.ShopLogoRequest logo
+	String logoObjectKey
 ){}

--- a/src/main/java/com/roome/roome/be/domain/shop/dto/response/ShopDetailResponse.java
+++ b/src/main/java/com/roome/roome/be/domain/shop/dto/response/ShopDetailResponse.java
@@ -4,12 +4,14 @@ import com.roome.roome.be.domain.shop.entity.Shop;
 
 public record ShopDetailResponse(
 	Long id,
-	String name
+	String name,
+	String logoUrl
 ) {
-	public static ShopDetailResponse from(Shop shop) {
+	public static ShopDetailResponse from(Shop shop, String logoUrl) {
 		return new ShopDetailResponse(
 			shop.getId(),
-			shop.getName()
+			shop.getName(),
+			logoUrl
 		);
 	}
 }

--- a/src/main/java/com/roome/roome/be/domain/shop/dto/response/ShopRegisterResponse.java
+++ b/src/main/java/com/roome/roome/be/domain/shop/dto/response/ShopRegisterResponse.java
@@ -4,9 +4,10 @@ import com.roome.roome.be.domain.shop.entity.Shop;
 
 public record ShopRegisterResponse(
 	Long shopId,
-	String name
+	String name,
+	String logoUrl
 ) {
-	public static ShopRegisterResponse from(Shop shop) {
-		return new ShopRegisterResponse(shop.getId(), shop.getName());
+	public static ShopRegisterResponse from(Shop shop, String logoUrl) {
+		return new ShopRegisterResponse(shop.getId(), shop.getName(), logoUrl);
 	}
 }

--- a/src/main/java/com/roome/roome/be/domain/shop/dto/response/ShopSummaryResponse.java
+++ b/src/main/java/com/roome/roome/be/domain/shop/dto/response/ShopSummaryResponse.java
@@ -4,12 +4,14 @@ import com.roome.roome.be.domain.shop.entity.Shop;
 
 public record ShopSummaryResponse(
 	Long id,
-	String name
+	String name,
+	String logoUrl
 ) {
-	public static ShopSummaryResponse from(Shop shop) {
+	public static ShopSummaryResponse from(Shop shop, String logoUrl) {
 		return new ShopSummaryResponse(
 			shop.getId(),
-			shop.getName()
+			shop.getName(),
+			logoUrl
 		);
 	}
 }

--- a/src/main/java/com/roome/roome/be/domain/shop/entity/Shop.java
+++ b/src/main/java/com/roome/roome/be/domain/shop/entity/Shop.java
@@ -27,6 +27,9 @@ public class Shop extends BaseEntity {
 	@Column(nullable = false, length = 50)
 	private String name;
 
+	@Column(name = "logo_object_key", length = 300)
+	private String logoObjectKey;
+
 	public void updateName(String name) {
 		this.name = name;
 	}

--- a/src/main/java/com/roome/roome/be/domain/shop/entity/Shop.java
+++ b/src/main/java/com/roome/roome/be/domain/shop/entity/Shop.java
@@ -34,4 +34,8 @@ public class Shop extends BaseEntity {
 		this.name = name;
 	}
 
+	public void updateLogoObjectKey(String objectKey) {
+		this.logoObjectKey = objectKey;
+	}
+
 }

--- a/src/main/java/com/roome/roome/be/domain/shop/service/ShopService.java
+++ b/src/main/java/com/roome/roome/be/domain/shop/service/ShopService.java
@@ -41,13 +41,13 @@ public class ShopService {
 	public ShopRegisterResponse registerShop(ShopRegisterRequest shopRegisterRequest) {
 		Shop saved = shopRepository.save(Shop.builder()
 			.name(shopRegisterRequest.name())
-			.build());                                           // 먼저 저장해서 shopId 확보
+			.build());
 
-		commitLogoIfPresent(saved, shopRegisterRequest.logo());                  // 로고가 있으면 이동/반영
+		commitLogoIfPresent(saved, shopRegisterRequest.logo());
 
 		String logoUrl = (saved.getLogoObjectKey() != null && !saved.getLogoObjectKey().isBlank())
 			? imageUrlBuilder.build(saved.getLogoObjectKey())
-			: defaultShopLogoUrl;                                // 기본 이미지 fallback
+			: defaultShopLogoUrl;
 
 		return ShopRegisterResponse.from(saved, logoUrl);
 	}
@@ -59,7 +59,7 @@ public class ShopService {
 			.orElseThrow(() -> new GeneralException(ErrorStatus.SHOP_NOT_FOUND));
 
 		if (shopUpdateRequest.name() != null) shop.updateName(shopUpdateRequest.name());
-		commitLogoIfPresent(shop, shopUpdateRequest.logo());                   // 로고 교체 시에도 동일 로직 재사용
+		commitLogoIfPresent(shop, shopUpdateRequest.logo());
 	}
 
 
@@ -78,10 +78,9 @@ public class ShopService {
 		Shop shop = shopRepository.findById(shopId)
 			.orElseThrow(() -> new GeneralException(ErrorStatus.SHOP_NOT_FOUND));
 
-		// S3 objectKey → CDN URL 변환
 		String logoUrl = (shop.getLogoObjectKey() != null && !shop.getLogoObjectKey().isBlank())
 			? imageUrlBuilder.build(shop.getLogoObjectKey())
-			: defaultShopLogoUrl; // 기본 이미지 fallback
+			: defaultShopLogoUrl; // 기본 이미지
 
 		return ShopDetailResponse.from(shop, logoUrl);
 	}
@@ -119,13 +118,13 @@ public class ShopService {
 	private void commitLogoIfPresent(Shop shop, ShopRegisterRequest.ShopLogoRequest logo) {
 		if (logo == null || logo.objectKey() == null || logo.objectKey().isBlank()) return;
 
-		String source = logo.objectKey();                        // e.g. uploads/{sessionId}/detail/xxx.jpg
+		String source = logo.objectKey();
 		String ext = source.substring(source.lastIndexOf('.') + 1);
 		String dest = "shops/%d/profile/%s.%s".formatted(
 			shop.getId(), java.util.UUID.randomUUID(), ext
 		);
 
-		s3Service.moveAll(java.util.Map.of(source, dest));       // S3 임시 → 영구 경로로 이동
-		shop.updateLogoObjectKey(dest);                          // 엔티티에 최종 objectKey 반영
+		s3Service.moveAll(java.util.Map.of(source, dest));
+		shop.updateLogoObjectKey(dest);
 	}
 }

--- a/src/main/java/com/roome/roome/be/domain/shop/service/ShopService.java
+++ b/src/main/java/com/roome/roome/be/domain/shop/service/ShopService.java
@@ -43,7 +43,7 @@ public class ShopService {
 			.name(shopRegisterRequest.name())
 			.build());
 
-		commitLogoIfPresent(saved, shopRegisterRequest.logo());
+		commitLogoIfPresent(saved, shopRegisterRequest.logoObjectKey());
 
 		String logoUrl = (saved.getLogoObjectKey() != null && !saved.getLogoObjectKey().isBlank())
 			? imageUrlBuilder.build(saved.getLogoObjectKey())
@@ -59,7 +59,7 @@ public class ShopService {
 			.orElseThrow(() -> new GeneralException(ErrorStatus.SHOP_NOT_FOUND));
 
 		if (shopUpdateRequest.name() != null) shop.updateName(shopUpdateRequest.name());
-		commitLogoIfPresent(shop, shopUpdateRequest.logo());
+		commitLogoIfPresent(shop, shopUpdateRequest.logoObjectKey());
 	}
 
 
@@ -115,10 +115,10 @@ public class ShopService {
 	}
 
 	// ShopService.java
-	private void commitLogoIfPresent(Shop shop, ShopRegisterRequest.ShopLogoRequest logo) {
-		if (logo == null || logo.objectKey() == null || logo.objectKey().isBlank()) return;
+	private void commitLogoIfPresent(Shop shop, String logoObjectKey) {
+		if (logoObjectKey == null || logoObjectKey.isBlank()) return;
 
-		String source = logo.objectKey();
+		String source = logoObjectKey;
 		String ext = source.substring(source.lastIndexOf('.') + 1);
 		String dest = "shops/%d/profile/%s.%s".formatted(
 			shop.getId(), java.util.UUID.randomUUID(), ext

--- a/src/main/java/com/roome/roome/be/domain/shop/service/ShopService.java
+++ b/src/main/java/com/roome/roome/be/domain/shop/service/ShopService.java
@@ -2,6 +2,7 @@ package com.roome.roome.be.domain.shop.service;
 
 import java.util.List;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -10,6 +11,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.roome.roome.be.common.exception.GeneralException;
+import com.roome.roome.be.common.s3.service.ImageUrlBuilder;
+import com.roome.roome.be.common.s3.service.S3Service;
 import com.roome.roome.be.common.status.ErrorStatus;
 import com.roome.roome.be.domain.shop.dto.request.ShopRegisterRequest;
 import com.roome.roome.be.domain.shop.dto.request.ShopUpdateRequest;
@@ -20,7 +23,6 @@ import com.roome.roome.be.domain.shop.dto.response.ShopSummaryResponse;
 import com.roome.roome.be.domain.shop.entity.Shop;
 import com.roome.roome.be.domain.shop.repository.ShopRepository;
 
-
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -28,28 +30,38 @@ import lombok.RequiredArgsConstructor;
 public class ShopService {
 
 	private final ShopRepository shopRepository;
+	private final S3Service s3Service;
+	private final ImageUrlBuilder imageUrlBuilder;
+
+	@Value("${storage.defaults.shop-logo}")
+	private String defaultShopLogoUrl;
 
 	//가게 등록
 	@Transactional
 	public ShopRegisterResponse registerShop(ShopRegisterRequest shopRegisterRequest) {
-		Shop shop = Shop.builder()
+		Shop saved = shopRepository.save(Shop.builder()
 			.name(shopRegisterRequest.name())
-			.build();
+			.build());                                           // 먼저 저장해서 shopId 확보
 
-		Shop savedShop = shopRepository.save(shop);
-		return ShopRegisterResponse.from(savedShop);
+		commitLogoIfPresent(saved, shopRegisterRequest.logo());                  // 로고가 있으면 이동/반영
+
+		String logoUrl = (saved.getLogoObjectKey() != null && !saved.getLogoObjectKey().isBlank())
+			? imageUrlBuilder.build(saved.getLogoObjectKey())
+			: defaultShopLogoUrl;                                // 기본 이미지 fallback
+
+		return ShopRegisterResponse.from(saved, logoUrl);
 	}
 
-	//가게 이름 수정
+	//가게 수정
 	@Transactional
 	public void updateShop(Long shopId, ShopUpdateRequest shopUpdateRequest) {
 		Shop shop = shopRepository.findById(shopId)
 			.orElseThrow(() -> new GeneralException(ErrorStatus.SHOP_NOT_FOUND));
 
-		if (shopUpdateRequest.name() != null) {
-			shop.updateName(shopUpdateRequest.name());
-		}
+		if (shopUpdateRequest.name() != null) shop.updateName(shopUpdateRequest.name());
+		commitLogoIfPresent(shop, shopUpdateRequest.logo());                   // 로고 교체 시에도 동일 로직 재사용
 	}
+
 
 	//가게 삭제
 	@Transactional
@@ -62,11 +74,16 @@ public class ShopService {
 
 	//가게 상세 조회, 추후 상세 내용 보완
 	@Transactional(readOnly=true)
-	public ShopDetailResponse getShopDetail(Long shopId){
+	public ShopDetailResponse getShopDetail(Long shopId) {
 		Shop shop = shopRepository.findById(shopId)
 			.orElseThrow(() -> new GeneralException(ErrorStatus.SHOP_NOT_FOUND));
-		return ShopDetailResponse.from(shop);
 
+		// S3 objectKey → CDN URL 변환
+		String logoUrl = (shop.getLogoObjectKey() != null && !shop.getLogoObjectKey().isBlank())
+			? imageUrlBuilder.build(shop.getLogoObjectKey())
+			: defaultShopLogoUrl; // 기본 이미지 fallback
+
+		return ShopDetailResponse.from(shop, logoUrl);
 	}
 
 	//가게 목록 조회
@@ -81,9 +98,13 @@ public class ShopService {
 			shops = shopRepository.findAll(pageable);
 		}
 
-		List<ShopSummaryResponse> content = shops
-			.stream()
-			.map(ShopSummaryResponse::from)
+		List<ShopSummaryResponse> content = shops.stream()
+			.map(shop -> {
+				String logoUrl = (shop.getLogoObjectKey() != null && !shop.getLogoObjectKey().isBlank())
+					? imageUrlBuilder.build(shop.getLogoObjectKey())
+					: defaultShopLogoUrl;
+				return ShopSummaryResponse.from(shop, logoUrl);
+			})
 			.toList();
 
 		return new ShopListResponse(
@@ -94,4 +115,17 @@ public class ShopService {
 		);
 	}
 
+	// ShopService.java
+	private void commitLogoIfPresent(Shop shop, ShopRegisterRequest.ShopLogoRequest logo) {
+		if (logo == null || logo.objectKey() == null || logo.objectKey().isBlank()) return;
+
+		String source = logo.objectKey();                        // e.g. uploads/{sessionId}/detail/xxx.jpg
+		String ext = source.substring(source.lastIndexOf('.') + 1);
+		String dest = "shops/%d/profile/%s.%s".formatted(
+			shop.getId(), java.util.UUID.randomUUID(), ext
+		);
+
+		s3Service.moveAll(java.util.Map.of(source, dest));       // S3 임시 → 영구 경로로 이동
+		shop.updateLogoObjectKey(dest);                          // 엔티티에 최종 objectKey 반영
+	}
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -79,4 +79,5 @@ server:
 
 storage:
   cdn-base-url: ${CDN_BASE_URL}
-
+  defaults:
+    shop-logo: ${SHOP_LOGO}


### PR DESCRIPTION
## #️⃣ 관련 이슈
closed #26 

## 💡 작업 배경
현재 가게는 이름만 받고 있다. 따라서 로고 이미지도 함께 받고 반환할 수 있도록 변경이 필요했다.


## 🧩 작업 내용

- 가게 등록시 로고 이미지 presignedurl로 발급 받도록 구현
- 가게 등록시 이미지 objectkey로 함께 받고 반환시 가게 이름과 logourl 반환, 로고 이미지 미등록시 기본 이미지 설정
- 가게 수정시 로고도 수정가능하도록 구현 
- 목록, 상세 조회시 로고도 반환
- 일부 controller명 접두사 수정


## 📸 스크린샷(선택)
1. 가게 등록시 로고 이미지 presignedurl로 발급 받도록 구현

<img width="1001" height="781" alt="Screenshot 2025-11-09 at 4 49 49 PM" src="https://github.com/user-attachments/assets/c805f87f-eebb-46ff-9a09-38c5bdc25849" />

2. 가게 등록시 이미지 objectkey로 함께 받고 반환시 가게 이름과 logourl 반환, 로고 이미지 미등록시 기본 이미지 설정

<img width="1042" height="817" alt="Screenshot 2025-11-09 at 4 49 37 PM" src="https://github.com/user-attachments/assets/3d17fe6f-e464-49ff-ba1f-03bf8499881d" />

3. 목록, 상세 조회시 로고도 반환
<img width="1134" height="856" alt="Screenshot 2025-11-09 at 4 50 18 PM" src="https://github.com/user-attachments/assets/0d1848f0-bce9-404a-9b6f-62a8c9a45278" />


## 📝 기타
기본 이미지는 추후 바꾸겠습니다.