### PR TITLE
[Fix] phoneNumber 컬럼의 NOT NULL 제약으로 인한 소셜 로그인 오류 수정

### DIFF
--- a/src/main/java/com/roome/roome/be/domain/user/entity/User.java
+++ b/src/main/java/com/roome/roome/be/domain/user/entity/User.java
@@ -28,7 +28,7 @@ public class User extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private LoginType loginType;
 
-    @Column(nullable = false, length = 20)
+    @Column(length = 20)
     private String phoneNumber;
 
     private String providerId;


### PR DESCRIPTION
## #️⃣ 관련 이슈
closed #35 

## 💡 작업 배경
- 구글/카카오 로그인 시 phoneNumber가 전달되지 않아 null 값으로 DB에 저장되던 중, user 테이블의 phone_number 컬럼이 NOT NULL 제약으로 설정되어 있어 DataIntegrityViolationException (500 Internal Server Error) 발생
- 이미 생성된 DB 스키마의 제약 조건이 변경되지 않아 db에서 직접 제약 조건 수정


## 🧩 작업 내용
- User 엔티티의 phoneNumber 컬럼을 nullable = true로 수정
- db에서 직접 제약 조건 변경

## 📸 스크린샷(선택)
<img width="1508" height="456" alt="Screenshot 2025-11-12 at 1 41 57 AM" src="https://github.com/user-attachments/assets/539486f6-ac7b-45cc-89ba-56589d541787" />


## 📝 기타
