### PR TITLE
[Feat] 레퍼런스 관련 기능 추가

### DIFF
--- a/src/main/java/com/roome/roome/be/common/s3/enums/StorageScope.java
+++ b/src/main/java/com/roome/roome/be/common/s3/enums/StorageScope.java
@@ -5,5 +5,7 @@ public enum StorageScope {
     SHOP_PROFILE,
     PRODUCT_DETAIL,
     //임시저장용
-    UPLOAD_SESSION
+    UPLOAD_SESSION,
+    // 레퍼런스용
+    REFERENCE;
 }

--- a/src/main/java/com/roome/roome/be/common/s3/service/S3Service.java
+++ b/src/main/java/com/roome/roome/be/common/s3/service/S3Service.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
+import com.amazonaws.services.s3.model.ObjectMetadata;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,6 +24,7 @@ import com.roome.roome.be.common.s3.enums.StorageScope;
 import com.roome.roome.be.common.status.ErrorStatus;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
@@ -78,6 +80,7 @@ public class S3Service {
 			case SHOP_PROFILE   -> "shops/%d/profile/%s.%s".formatted(id, uuid, ext);
 			case PRODUCT_DETAIL -> "products/%d/detail/%s.%s".formatted(id, uuid, ext);
 			case UPLOAD_SESSION -> "uploads/%d/detail/%s.%s".formatted(id, uuid, ext);
+			case REFERENCE      -> "references/%d/%s.%s".formatted(id, uuid, ext); // ★ 추가
 		};
 	}
 
@@ -102,5 +105,23 @@ public class S3Service {
 		amazonS3.deleteObject(bucket, objectKey);
 	}
 
+	public String uploadObject(StorageScope storageScope, long id, MultipartFile file) {
+		validate(file.getContentType(), file.getSize());
+
+		String ext = CT_TO_EXT.get(file.getContentType());
+		String objectKey = buildKey(storageScope, id, ext);
+
+		try{
+			ObjectMetadata metadata = new ObjectMetadata();
+			metadata.setContentType(file.getContentType());
+			metadata.setContentLength(file.getSize());
+
+			amazonS3.putObject(bucket, objectKey, file.getInputStream(), metadata);
+		}catch (Exception e){
+			throw new GeneralException(ErrorStatus.FILE_TOO_LARGE);
+		}
+
+		return objectKey;
+	}
 }
 

--- a/src/main/java/com/roome/roome/be/common/status/ErrorStatus.java
+++ b/src/main/java/com/roome/roome/be/common/status/ErrorStatus.java
@@ -72,6 +72,7 @@ public enum ErrorStatus implements BaseStatus {
      */
     INVALID_FILE_TYPE("S3-001", HttpStatus.BAD_REQUEST, "허용되지 않은 파일 형식입니다."),
     FILE_TOO_LARGE( "S3-002", HttpStatus.BAD_REQUEST,"파일 크기가 5MB를 초과했습니다."),
+    S3_SERVER_ERROR("S3_500", HttpStatus.INTERNAL_SERVER_ERROR,"S3 업로드 중 오류가 발생하였습니다."),
 
     /**
      * Tag
@@ -83,7 +84,12 @@ public enum ErrorStatus implements BaseStatus {
      * Product
      */
     PRODUCT_NOT_FOUND("PRODUCT_404", HttpStatus.NOT_FOUND, "존재하지 않는 상품입니다."),
-    INVALID_IMAGE_ORDER("PRODUCT_400", HttpStatus.BAD_REQUEST,  "잘못된 이미지 순서입니다.");
+    INVALID_IMAGE_ORDER("PRODUCT_400", HttpStatus.BAD_REQUEST,  "잘못된 이미지 순서입니다."),
+
+    /**
+     * Reference
+     */
+    REFERENCE_NOT_FOUND("REFERENCE_404", HttpStatus.NOT_FOUND, "존재하지 않는 레퍼런스입니다.");
         
 
     private final String code;

--- a/src/main/java/com/roome/roome/be/common/status/SuccessStatus.java
+++ b/src/main/java/com/roome/roome/be/common/status/SuccessStatus.java
@@ -68,7 +68,8 @@ public enum SuccessStatus implements BaseStatus {
      * Reference
      */
     REGISTER_REFERENCE_SUCCESS("REFERENCE_201", HttpStatus.CREATED,"레퍼런스 등록 성공"),
-    REGISTER_REFERENCE_IMAGE_SUCCESS("REFERENCE_201", HttpStatus.CREATED,"레퍼런스 이미지 등록 성공");
+    REGISTER_REFERENCE_IMAGE_SUCCESS("REFERENCE_201", HttpStatus.CREATED,"레퍼런스 이미지 등록 성공"),
+    CREATE_REFERENCE_200_SCRAP("REFERENCE_200", HttpStatus.OK, "레퍼런스 스크랩 토글 성공");
 
     private final String code;
     private final HttpStatus httpStatus;

--- a/src/main/java/com/roome/roome/be/common/status/SuccessStatus.java
+++ b/src/main/java/com/roome/roome/be/common/status/SuccessStatus.java
@@ -50,6 +50,7 @@ public enum SuccessStatus implements BaseStatus {
      * S3
      */
     S3_PRESIGNED_ISSUE_SUCCESS("S3_200", HttpStatus.OK, "Presigned URL 발급 성공"),
+    S3_COMMIT_SUCCESS("S3_200",HttpStatus.OK,"S3 이미지 업로드 성공"),
 
     /**
      * Product
@@ -61,7 +62,13 @@ public enum SuccessStatus implements BaseStatus {
     GET_PRODUCT_LIST("PRODUCT_200", HttpStatus.OK, "상품 목록 조회 성공"),
     UPDATE_PRODUCT_SUCCESS("PRODUCT_200", HttpStatus.OK,"상품 수정 성공"),
     UPDATE_PRODUCT_IMAGES_SUCCESS("PRODUCT_200", HttpStatus.OK,"상품 이미지 수정 성공"),
-    DELETE_PRODUCT_SUCCESS("PRODUCT_200", HttpStatus.OK, "상품 삭제 성공");
+    DELETE_PRODUCT_SUCCESS("PRODUCT_200", HttpStatus.OK, "상품 삭제 성공"),
+
+    /**
+     * Reference
+     */
+    REGISTER_REFERENCE_SUCCESS("REFERENCE_201", HttpStatus.CREATED,"레퍼런스 등록 성공"),
+    REGISTER_REFERENCE_IMAGE_SUCCESS("REFERENCE_201", HttpStatus.CREATED,"레퍼런스 이미지 등록 성공");
 
     private final String code;
     private final HttpStatus httpStatus;

--- a/src/main/java/com/roome/roome/be/common/status/SuccessStatus.java
+++ b/src/main/java/com/roome/roome/be/common/status/SuccessStatus.java
@@ -69,7 +69,8 @@ public enum SuccessStatus implements BaseStatus {
      */
     REGISTER_REFERENCE_SUCCESS("REFERENCE_201", HttpStatus.CREATED,"레퍼런스 등록 성공"),
     REGISTER_REFERENCE_IMAGE_SUCCESS("REFERENCE_201", HttpStatus.CREATED,"레퍼런스 이미지 등록 성공"),
-    CREATE_REFERENCE_200_SCRAP("REFERENCE_200", HttpStatus.OK, "레퍼런스 스크랩 토글 성공");
+    CREATE_REFERENCE_SCRAP("REFERENCE_200", HttpStatus.OK, "레퍼런스 스크랩 토글 성공"),
+    GET_REFERENCE_LIST_SUCCESS("REFERENCE_200",HttpStatus.OK,"레퍼런스 리스트 조회 성공");
 
     private final String code;
     private final HttpStatus httpStatus;

--- a/src/main/java/com/roome/roome/be/domain/product/controller/ProductController.java
+++ b/src/main/java/com/roome/roome/be/domain/product/controller/ProductController.java
@@ -154,7 +154,7 @@ public class ProductController {
 	}
 
 	// 상품 스크랩 기능 구현
-	@PostMapping("{productId}/scrap")
+	@PostMapping("/{productId}/scrap")
 	@Operation(
 			summary = "상품 스크랩 토글",
 			description = "이미 스크랩이 되어 있으면 취소하고, 되어 있지 않으면 스크랩에 추가합니다."
@@ -162,7 +162,7 @@ public class ProductController {
 	@Parameters({
 			@Parameter(name = "productId", description = "스크랩할 상품의 ID", example = "123"),
 	})
-	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "스크랩 토글 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ProductToggleLikeResponse.class)))
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "스크랩 토글 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ProductToggleScrapResponse.class)))
 	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "유저가 존재하지 않거나 상품이 존재하지 않음", content = @Content(mediaType = "application/json"))
 	public ResponseEntity<ApiResponse<ProductToggleScrapResponse>> toggleProductScrap(
 			@PathVariable("productId") Long productId,

--- a/src/main/java/com/roome/roome/be/domain/reference/controller/ReferenceController.java
+++ b/src/main/java/com/roome/roome/be/domain/reference/controller/ReferenceController.java
@@ -1,0 +1,37 @@
+package com.roome.roome.be.domain.reference.controller;
+
+import com.roome.roome.be.common.response.ApiResponse;
+import com.roome.roome.be.common.status.SuccessStatus;
+import com.roome.roome.be.domain.reference.service.ReferenceService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/references")
+@Tag(name = "Reference")
+public class ReferenceController {
+    private final ReferenceService referenceService;
+
+    @PostMapping(value = "", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(
+            summary = "레퍼런스 업로드",
+            description = "레퍼런스 생성 && 레퍼런스 이미지 등록"
+    )
+    public ResponseEntity<ApiResponse<Void>> createReference(
+            @AuthenticationPrincipal Long userId,
+            @RequestPart("files") List<MultipartFile> files
+    ){
+        referenceService.registerReference(userId,files);
+        return ApiResponse.success(SuccessStatus.REGISTER_REFERENCE_SUCCESS);
+    }
+
+}

--- a/src/main/java/com/roome/roome/be/domain/reference/controller/ReferenceController.java
+++ b/src/main/java/com/roome/roome/be/domain/reference/controller/ReferenceController.java
@@ -2,8 +2,13 @@ package com.roome.roome.be.domain.reference.controller;
 
 import com.roome.roome.be.common.response.ApiResponse;
 import com.roome.roome.be.common.status.SuccessStatus;
+import com.roome.roome.be.domain.reference.dto.response.ReferenceToggleScrapResponse;
 import com.roome.roome.be.domain.reference.service.ReferenceService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
@@ -34,4 +39,21 @@ public class ReferenceController {
         return ApiResponse.success(SuccessStatus.REGISTER_REFERENCE_SUCCESS);
     }
 
+    @PostMapping("/{referenceId}/scrap")
+    @Operation(
+            summary = "레퍼런스 스크랩 토글 ",
+            description = "이미 스크랩이 되어 있으면 취소하고, 되어 있지 않으면 스크랩에 추가합니다."
+    )
+    @Parameters({
+            @Parameter(name = "referenceId", description = "스크랩할 Reference ID", example = "1")
+    })
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "스크랩 토글 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ReferenceToggleScrapResponse.class)))
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "유저가 존재하지 않거나 레퍼런스가 존재하지 않음", content = @Content(mediaType = "application/json"))
+    public ResponseEntity<ApiResponse<ReferenceToggleScrapResponse>> toggleProductScrap(
+            @PathVariable("referenceId") Long referenceId,
+            @AuthenticationPrincipal Long userId
+    ) {
+        ReferenceToggleScrapResponse response = referenceService.toggleReferenceScrap(referenceId, userId);
+        return ApiResponse.success(SuccessStatus.CREATE_REFERENCE_200_SCRAP,response);
+    }
 }

--- a/src/main/java/com/roome/roome/be/domain/reference/controller/ReferenceController.java
+++ b/src/main/java/com/roome/roome/be/domain/reference/controller/ReferenceController.java
@@ -2,6 +2,7 @@ package com.roome.roome.be.domain.reference.controller;
 
 import com.roome.roome.be.common.response.ApiResponse;
 import com.roome.roome.be.common.status.SuccessStatus;
+import com.roome.roome.be.domain.reference.dto.response.ReferenceListResponse;
 import com.roome.roome.be.domain.reference.dto.response.ReferenceToggleScrapResponse;
 import com.roome.roome.be.domain.reference.service.ReferenceService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -25,6 +26,19 @@ import java.util.List;
 @Tag(name = "Reference")
 public class ReferenceController {
     private final ReferenceService referenceService;
+
+    @GetMapping("")
+    @Operation(
+            summary = "레퍼런스 리스트 조회",
+            description = "레퍼런스 리스트를 사용자에 맞게 출력합니다."
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "스크랩 내역 리스트 조회 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ReferenceListResponse.class)))
+    public ResponseEntity<ApiResponse<ReferenceListResponse>> getReferenceList(
+      @AuthenticationPrincipal Long userId
+    ){
+        ReferenceListResponse response = referenceService.getReferenceList(userId);
+        return ApiResponse.success(SuccessStatus.GET_REFERENCE_LIST_SUCCESS,response);
+    }
 
     @PostMapping(value = "", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(
@@ -54,6 +68,6 @@ public class ReferenceController {
             @AuthenticationPrincipal Long userId
     ) {
         ReferenceToggleScrapResponse response = referenceService.toggleReferenceScrap(referenceId, userId);
-        return ApiResponse.success(SuccessStatus.CREATE_REFERENCE_200_SCRAP,response);
+        return ApiResponse.success(SuccessStatus.CREATE_REFERENCE_SCRAP,response);
     }
 }

--- a/src/main/java/com/roome/roome/be/domain/reference/dto/request/RegisterReferenceImageListRequest.java
+++ b/src/main/java/com/roome/roome/be/domain/reference/dto/request/RegisterReferenceImageListRequest.java
@@ -1,0 +1,10 @@
+package com.roome.roome.be.domain.reference.dto.request;
+
+
+import java.util.List;
+
+public record RegisterReferenceImageListRequest(
+        Long referenceId,
+        List<String> objectKeys
+) {
+}

--- a/src/main/java/com/roome/roome/be/domain/reference/dto/request/RegisterReferenceRequest.java
+++ b/src/main/java/com/roome/roome/be/domain/reference/dto/request/RegisterReferenceRequest.java
@@ -1,0 +1,10 @@
+package com.roome.roome.be.domain.reference.dto.request;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+public record RegisterReferenceRequest(
+        List<MultipartFile> files
+) {
+}

--- a/src/main/java/com/roome/roome/be/domain/reference/dto/response/CommonReferenceInfo.java
+++ b/src/main/java/com/roome/roome/be/domain/reference/dto/response/CommonReferenceInfo.java
@@ -1,0 +1,12 @@
+package com.roome.roome.be.domain.reference.dto.response;
+
+import java.util.List;
+
+public record CommonReferenceInfo(
+        Long referenceId,
+        String nickname,
+        Long userId,
+        List<String> imageUrlList,
+        Integer scrapCount
+) {
+}

--- a/src/main/java/com/roome/roome/be/domain/reference/dto/response/ReferenceListResponse.java
+++ b/src/main/java/com/roome/roome/be/domain/reference/dto/response/ReferenceListResponse.java
@@ -1,0 +1,8 @@
+package com.roome.roome.be.domain.reference.dto.response;
+
+import java.util.List;
+
+public record ReferenceListResponse(
+    List<CommonReferenceInfo> referenceList
+) {
+}

--- a/src/main/java/com/roome/roome/be/domain/reference/dto/response/ReferenceToggleScrapResponse.java
+++ b/src/main/java/com/roome/roome/be/domain/reference/dto/response/ReferenceToggleScrapResponse.java
@@ -1,0 +1,6 @@
+package com.roome.roome.be.domain.reference.dto.response;
+
+public record ReferenceToggleScrapResponse(
+        boolean scrapped
+) {
+}

--- a/src/main/java/com/roome/roome/be/domain/reference/entity/Reference.java
+++ b/src/main/java/com/roome/roome/be/domain/reference/entity/Reference.java
@@ -1,0 +1,30 @@
+package com.roome.roome.be.domain.reference.entity;
+
+import com.roome.roome.be.common.base.BaseEntity;
+import com.roome.roome.be.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Reference extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "like_count",nullable = false)
+    private Integer likeCount;
+
+    @OneToMany(mappedBy = "reference", fetch = FetchType.LAZY)
+    private List<ReferenceImage> referenceImageList = new ArrayList<>();
+}

--- a/src/main/java/com/roome/roome/be/domain/reference/entity/Reference.java
+++ b/src/main/java/com/roome/roome/be/domain/reference/entity/Reference.java
@@ -22,8 +22,8 @@ public class Reference extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @Column(name = "like_count",nullable = false)
-    private Integer likeCount;
+    @Column(name = "scrap_count",nullable = false)
+    private Integer scrapCount;
 
     @OneToMany(mappedBy = "reference", fetch = FetchType.LAZY)
     private List<ReferenceImage> referenceImageList = new ArrayList<>();

--- a/src/main/java/com/roome/roome/be/domain/reference/entity/ReferenceImage.java
+++ b/src/main/java/com/roome/roome/be/domain/reference/entity/ReferenceImage.java
@@ -1,0 +1,23 @@
+package com.roome.roome.be.domain.reference.entity;
+
+import com.roome.roome.be.common.base.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class ReferenceImage extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "reference_id", nullable = false)
+    private Reference reference;
+
+    @Column(nullable = false, length = 512, unique = true)
+    private String imageUrl;
+}

--- a/src/main/java/com/roome/roome/be/domain/reference/entity/ReferenceImage.java
+++ b/src/main/java/com/roome/roome/be/domain/reference/entity/ReferenceImage.java
@@ -18,6 +18,7 @@ public class ReferenceImage extends BaseEntity {
     @JoinColumn(name = "reference_id", nullable = false)
     private Reference reference;
 
-    @Column(nullable = false, length = 512, unique = true)
-    private String imageUrl;
+    @Column(nullable = false, length = 256, unique = true)
+    private String objectKey;
+
 }

--- a/src/main/java/com/roome/roome/be/domain/reference/repository/ReferenceImageRepository.java
+++ b/src/main/java/com/roome/roome/be/domain/reference/repository/ReferenceImageRepository.java
@@ -1,0 +1,9 @@
+package com.roome.roome.be.domain.reference.repository;
+
+import com.roome.roome.be.domain.reference.entity.ReferenceImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ReferenceImageRepository extends JpaRepository<ReferenceImage, Long> {
+}

--- a/src/main/java/com/roome/roome/be/domain/reference/repository/ReferenceRepository.java
+++ b/src/main/java/com/roome/roome/be/domain/reference/repository/ReferenceRepository.java
@@ -1,0 +1,9 @@
+package com.roome.roome.be.domain.reference.repository;
+
+import com.roome.roome.be.domain.reference.entity.Reference;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ReferenceRepository extends JpaRepository<Reference, Long> {
+}

--- a/src/main/java/com/roome/roome/be/domain/reference/service/ReferenceService.java
+++ b/src/main/java/com/roome/roome/be/domain/reference/service/ReferenceService.java
@@ -1,0 +1,53 @@
+package com.roome.roome.be.domain.reference.service;
+
+import com.roome.roome.be.common.exception.GeneralException;
+import com.roome.roome.be.common.s3.enums.StorageScope;
+import com.roome.roome.be.common.s3.service.S3Service;
+import com.roome.roome.be.common.status.ErrorStatus;
+import com.roome.roome.be.domain.reference.entity.Reference;
+import com.roome.roome.be.domain.reference.entity.ReferenceImage;
+import com.roome.roome.be.domain.reference.repository.ReferenceImageRepository;
+import com.roome.roome.be.domain.reference.repository.ReferenceRepository;
+import com.roome.roome.be.domain.user.entity.User;
+import com.roome.roome.be.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ReferenceService {
+
+    private final ReferenceRepository referenceRepository;
+    private final ReferenceImageRepository referenceImageRepository;
+    private final UserRepository userRepository;
+    private final S3Service s3Service;
+
+    // 레퍼런스 등록
+    public void registerReference(Long userId, List<MultipartFile> images ) {
+
+        if(images == null || images.isEmpty()) return;
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        Reference reference = referenceRepository.save(Reference.builder()
+                .user(user)
+                .likeCount(0)
+                .build());
+        Long referenceId = reference.getId();
+
+        List<ReferenceImage> referenceImageList = images.stream()
+                .map(file -> {
+                    String objectKey = s3Service.uploadObject(StorageScope.REFERENCE, referenceId, file);
+                    return ReferenceImage.builder()
+                            .reference(reference)
+                            .objectKey(objectKey) // 컬럼명 object_key 추천
+                            .build();
+                })
+                .toList();
+        referenceImageRepository.saveAll(referenceImageList);
+    }
+}

--- a/src/main/java/com/roome/roome/be/domain/reference/service/ReferenceService.java
+++ b/src/main/java/com/roome/roome/be/domain/reference/service/ReferenceService.java
@@ -2,8 +2,11 @@ package com.roome.roome.be.domain.reference.service;
 
 import com.roome.roome.be.common.exception.GeneralException;
 import com.roome.roome.be.common.s3.enums.StorageScope;
+import com.roome.roome.be.common.s3.service.ImageUrlBuilder;
 import com.roome.roome.be.common.s3.service.S3Service;
 import com.roome.roome.be.common.status.ErrorStatus;
+import com.roome.roome.be.domain.reference.dto.response.CommonReferenceInfo;
+import com.roome.roome.be.domain.reference.dto.response.ReferenceListResponse;
 import com.roome.roome.be.domain.reference.dto.response.ReferenceToggleScrapResponse;
 import com.roome.roome.be.domain.reference.entity.Reference;
 import com.roome.roome.be.domain.reference.entity.ReferenceImage;
@@ -17,6 +20,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 
@@ -28,7 +32,9 @@ public class ReferenceService {
     private final ReferenceImageRepository referenceImageRepository;
     private final UserRepository userRepository;
     private final UserScrapReferenceRepository userScrapReferenceRepository;
+
     private final S3Service s3Service;
+    private final ImageUrlBuilder imageUrlBuilder;
 
     // 레퍼런스 등록
     public void registerReference(Long userId, List<MultipartFile> images ) {
@@ -40,7 +46,7 @@ public class ReferenceService {
 
         Reference reference = referenceRepository.save(Reference.builder()
                 .user(user)
-                .likeCount(0)
+                .scrapCount(0)
                 .build());
         Long referenceId = reference.getId();
 
@@ -78,6 +84,35 @@ public class ReferenceService {
         }
 
         return new ReferenceToggleScrapResponse(scrapped);
+    }
+
+    public ReferenceListResponse getReferenceList(Long userId) {
+        // todo => 우선 유저만 불러온 뒤, 레퍼런스 관련 기획이 좀 더 상세화되면 그에 맞게 리스트 조회 기능 구체화, 우선은 좋아요 순으로 전체 레퍼런스 정렬
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        List<Reference> referenceList = referenceRepository.findAll();
+        List<CommonReferenceInfo> commonReferenceInfoList = referenceList.stream()
+                .sorted(Comparator.comparing(Reference::getScrapCount).reversed())
+                .map(
+                reference -> {
+                    List<String> imageUrlList = reference.getReferenceImageList().stream()
+                            .map(refImg -> imageUrlBuilder.build(
+                                    refImg.getObjectKey()
+                            ))
+                            .toList();
+
+                    return new CommonReferenceInfo(
+                            reference.getId(),
+                            reference.getUser().getNickname(),
+                            reference.getUser().getId(),
+                            imageUrlList,
+                            reference.getScrapCount()
+                    );
+                }
+
+        ).toList();
+        return new ReferenceListResponse(commonReferenceInfoList);
     }
 
     public Reference findReferenceById(Long referenceId) {

--- a/src/main/java/com/roome/roome/be/domain/reference/service/ReferenceService.java
+++ b/src/main/java/com/roome/roome/be/domain/reference/service/ReferenceService.java
@@ -4,17 +4,21 @@ import com.roome.roome.be.common.exception.GeneralException;
 import com.roome.roome.be.common.s3.enums.StorageScope;
 import com.roome.roome.be.common.s3.service.S3Service;
 import com.roome.roome.be.common.status.ErrorStatus;
+import com.roome.roome.be.domain.reference.dto.response.ReferenceToggleScrapResponse;
 import com.roome.roome.be.domain.reference.entity.Reference;
 import com.roome.roome.be.domain.reference.entity.ReferenceImage;
 import com.roome.roome.be.domain.reference.repository.ReferenceImageRepository;
 import com.roome.roome.be.domain.reference.repository.ReferenceRepository;
 import com.roome.roome.be.domain.user.entity.User;
+import com.roome.roome.be.domain.user.entity.UserScrapReference;
 import com.roome.roome.be.domain.user.repository.UserRepository;
+import com.roome.roome.be.domain.user.repository.UserScrapReferenceRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -23,6 +27,7 @@ public class ReferenceService {
     private final ReferenceRepository referenceRepository;
     private final ReferenceImageRepository referenceImageRepository;
     private final UserRepository userRepository;
+    private final UserScrapReferenceRepository userScrapReferenceRepository;
     private final S3Service s3Service;
 
     // 레퍼런스 등록
@@ -49,5 +54,34 @@ public class ReferenceService {
                 })
                 .toList();
         referenceImageRepository.saveAll(referenceImageList);
+    }
+
+    public ReferenceToggleScrapResponse toggleReferenceScrap(Long referenceId, Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+        Reference reference = findReferenceById(referenceId);
+
+        boolean scrapped;
+
+        Optional<UserScrapReference> existing = userScrapReferenceRepository.findByUserAndReference(user,reference);
+        if (existing.isEmpty()) {
+            UserScrapReference userScrapReference = UserScrapReference.builder()
+                    .user(user)
+                    .reference(reference)
+                    .build();
+            userScrapReferenceRepository.save(userScrapReference);
+            scrapped = true;
+        }
+        else {
+            userScrapReferenceRepository.delete(existing.get());
+            scrapped = false;
+        }
+
+        return new ReferenceToggleScrapResponse(scrapped);
+    }
+
+    public Reference findReferenceById(Long referenceId) {
+        return referenceRepository.findById(referenceId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.REFERENCE_NOT_FOUND));
     }
 }

--- a/src/main/java/com/roome/roome/be/domain/user/entity/UserScrapReference.java
+++ b/src/main/java/com/roome/roome/be/domain/user/entity/UserScrapReference.java
@@ -1,0 +1,26 @@
+package com.roome.roome.be.domain.user.entity;
+
+import com.roome.roome.be.common.base.BaseEntity;
+import com.roome.roome.be.domain.reference.entity.Reference;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class UserScrapReference extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "reference_id", nullable = false)
+    private Reference reference;
+}

--- a/src/main/java/com/roome/roome/be/domain/user/repository/UserScrapReferenceRepository.java
+++ b/src/main/java/com/roome/roome/be/domain/user/repository/UserScrapReferenceRepository.java
@@ -1,0 +1,14 @@
+package com.roome.roome.be.domain.user.repository;
+
+import com.roome.roome.be.domain.reference.entity.Reference;
+import com.roome.roome.be.domain.user.entity.User;
+import com.roome.roome.be.domain.user.entity.UserScrapReference;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserScrapReferenceRepository extends JpaRepository<UserScrapReference, Long> {
+    Optional<UserScrapReference> findByUserAndReference(User user, Reference reference);
+}


### PR DESCRIPTION
## #️⃣ 관련 이슈
closed #39

## 💡 작업 배경
피드에 필요한 API 추가

## 🧩 작업 내용
- [x] 레퍼런스 등록 기능 구현
- [x] 레퍼런스 리스트 조회 기능 구현
- [x] 레퍼런스 좋아요 토글 기능 구현
- [x] Reference, ReferenceImage, UserScrapReference Entity 추가


## 📸 스크린샷(선택)
<img width="1414" height="914" alt="image" src="https://github.com/user-attachments/assets/fe8fa6ff-7710-456c-8553-3d0463c4be3b" />
<img width="1414" height="914" alt="image" src="https://github.com/user-attachments/assets/d89a36ba-effc-458a-8b82-a4d8b80f1126" />
<img width="1414" height="841" alt="image" src="https://github.com/user-attachments/assets/092dcf06-fe5e-41a8-bfd4-e28f0c7ccbab" />


## 📝 기타
- 우선 레퍼런스 관련 기능부터 구현하였습니다.
- S3 서비스에서 Presigned관련 기능이 있는 걸 보긴 했는데, 프론트의 편의를 위해서 레퍼런스 등록 시 Multipart 형식으로 파일을 받아 레퍼런   스 생성 -> S3업로드 -> 레퍼런스 이미지 Entity 생성 순으로 작업하였습니다.
- 레퍼런스 리스트 조회 기능은 우선 스크랩 수를 기준으로 내림차순 하도록 하였고, 레퍼런스 관련 기획이 조금 더 구체화되면 그에 맞게 사용자 맞춤 로직으로 수정하겠습니다.