### PR TITLE
[Feat] 유저 관련 기능 추가

### DIFF
--- a/src/main/java/com/roome/roome/be/common/s3/enums/StorageScope.java
+++ b/src/main/java/com/roome/roome/be/common/s3/enums/StorageScope.java
@@ -7,5 +7,7 @@ public enum StorageScope {
     //임시저장용
     UPLOAD_SESSION,
     // 레퍼런스용
-    REFERENCE;
+    REFERENCE,
+    // 유저 프로필용
+    USER_PROFILE
 }

--- a/src/main/java/com/roome/roome/be/common/s3/enums/StorageScope.java
+++ b/src/main/java/com/roome/roome/be/common/s3/enums/StorageScope.java
@@ -5,5 +5,7 @@ public enum StorageScope {
     SHOP_PROFILE,
     PRODUCT_DETAIL,
     //임시저장용
-    UPLOAD_SESSION
+    UPLOAD_SESSION,
+    // 레퍼런스용
+    REFERENCE;
 }

--- a/src/main/java/com/roome/roome/be/common/s3/service/S3Service.java
+++ b/src/main/java/com/roome/roome/be/common/s3/service/S3Service.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
+import com.amazonaws.services.s3.model.ObjectMetadata;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,6 +24,7 @@ import com.roome.roome.be.common.s3.enums.StorageScope;
 import com.roome.roome.be.common.status.ErrorStatus;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
@@ -78,6 +80,7 @@ public class S3Service {
 			case SHOP_PROFILE   -> "shops/%d/profile/%s.%s".formatted(id, uuid, ext);
 			case PRODUCT_DETAIL -> "products/%d/detail/%s.%s".formatted(id, uuid, ext);
 			case UPLOAD_SESSION -> "uploads/%d/detail/%s.%s".formatted(id, uuid, ext);
+			case REFERENCE      -> "references/%d/%s.%s".formatted(id, uuid, ext); // ★ 추가
 		};
 	}
 
@@ -102,5 +105,23 @@ public class S3Service {
 		amazonS3.deleteObject(bucket, objectKey);
 	}
 
+	public String uploadObject(StorageScope storageScope, long id, MultipartFile file) {
+		validate(file.getContentType(), file.getSize());
+
+		String ext = CT_TO_EXT.get(file.getContentType());
+		String objectKey = buildKey(storageScope, id, ext);
+
+		try{
+			ObjectMetadata metadata = new ObjectMetadata();
+			metadata.setContentType(file.getContentType());
+			metadata.setContentLength(file.getSize());
+
+			amazonS3.putObject(bucket, objectKey, file.getInputStream(), metadata);
+		}catch (Exception e){
+			throw new GeneralException(ErrorStatus.FILE_TOO_LARGE);
+		}
+
+		return objectKey;
+	}
 }
 

--- a/src/main/java/com/roome/roome/be/common/s3/service/S3Service.java
+++ b/src/main/java/com/roome/roome/be/common/s3/service/S3Service.java
@@ -80,7 +80,8 @@ public class S3Service {
 			case SHOP_PROFILE   -> "shops/%d/profile/%s.%s".formatted(id, uuid, ext);
 			case PRODUCT_DETAIL -> "products/%d/detail/%s.%s".formatted(id, uuid, ext);
 			case UPLOAD_SESSION -> "uploads/%d/detail/%s.%s".formatted(id, uuid, ext);
-			case REFERENCE      -> "references/%d/%s.%s".formatted(id, uuid, ext); // ★ 추가
+			case REFERENCE      -> "references/%d/%s.%s".formatted(id, uuid, ext);
+			case USER_PROFILE -> "users/%d/profile/%s.%s".formatted(id, uuid, ext);
 		};
 	}
 

--- a/src/main/java/com/roome/roome/be/common/status/ErrorStatus.java
+++ b/src/main/java/com/roome/roome/be/common/status/ErrorStatus.java
@@ -72,6 +72,7 @@ public enum ErrorStatus implements BaseStatus {
      */
     INVALID_FILE_TYPE("S3-001", HttpStatus.BAD_REQUEST, "허용되지 않은 파일 형식입니다."),
     FILE_TOO_LARGE( "S3-002", HttpStatus.BAD_REQUEST,"파일 크기가 5MB를 초과했습니다."),
+    S3_SERVER_ERROR("S3_500", HttpStatus.INTERNAL_SERVER_ERROR,"S3 업로드 중 오류가 발생하였습니다."),
 
     /**
      * Tag
@@ -83,7 +84,12 @@ public enum ErrorStatus implements BaseStatus {
      * Product
      */
     PRODUCT_NOT_FOUND("PRODUCT_404", HttpStatus.NOT_FOUND, "존재하지 않는 상품입니다."),
-    INVALID_IMAGE_ORDER("PRODUCT_400", HttpStatus.BAD_REQUEST,  "잘못된 이미지 순서입니다.");
+    INVALID_IMAGE_ORDER("PRODUCT_400", HttpStatus.BAD_REQUEST,  "잘못된 이미지 순서입니다."),
+
+    /**
+     * Reference
+     */
+    REFERENCE_NOT_FOUND("REFERENCE_404", HttpStatus.NOT_FOUND, "존재하지 않는 레퍼런스입니다.");
         
 
     private final String code;

--- a/src/main/java/com/roome/roome/be/common/status/SuccessStatus.java
+++ b/src/main/java/com/roome/roome/be/common/status/SuccessStatus.java
@@ -33,8 +33,8 @@ public enum SuccessStatus implements BaseStatus {
     /**
      * User
      */
-    SAVE_USER_ONBOARDING("AUTH_201", HttpStatus.CREATED, "유저 온보딩 저장 성공"),
-    CHECK_USER_ONBOARDING_EXISTENCE("AUTH_200", HttpStatus.OK, "유저 온보딩 존재 여부 조회 성공"),
+    SAVE_USER_ONBOARDING_SUCCESS("AUTH_201", HttpStatus.CREATED, "유저 온보딩 저장 성공"),
+    CHECK_USER_ONBOARDING_EXISTENCE_SUCCESS("AUTH_200", HttpStatus.OK, "유저 온보딩 존재 여부 조회 성공"),
     GET_USER_LIKE_PRODUCT_LIST_SUCCESS("USER_200",HttpStatus.OK, "유저 좋아요 상품 리스트 조회 성공"),
     GET_USER_SCRAP_PRODUCT_LIST_SUCCESS("USER_200",HttpStatus.OK, "유저 스크랩 상품 리스트 조회 성공"),
     GET_USER_SCRAP_REFERENCE_LIST_SUCCESS("USER_200",HttpStatus.OK, "유저 스크랩 레퍼런스 리스트 조회 성공"),

--- a/src/main/java/com/roome/roome/be/common/status/SuccessStatus.java
+++ b/src/main/java/com/roome/roome/be/common/status/SuccessStatus.java
@@ -36,6 +36,8 @@ public enum SuccessStatus implements BaseStatus {
     SAVE_USER_ONBOARDING("AUTH_201", HttpStatus.CREATED, "유저 온보딩 저장 성공"),
     CHECK_USER_ONBOARDING_EXISTENCE("AUTH_200", HttpStatus.OK, "유저 온보딩 존재 여부 조회 성공"),
     GET_USER_LIKE_PRODUCT_LIST_SUCCESS("USER_200",HttpStatus.OK, "유저 좋아요 상품 리스트 조회 성공"),
+    GET_USER_SCRAP_PRODUCT_LIST_SUCCESS("USER_200",HttpStatus.OK, "유저 스크랩 상품 리스트 조회 성공"),
+    GET_USER_SCRAP_REFERENCE_LIST_SUCCESS("USER_200",HttpStatus.OK, "유저 스크랩 레퍼런스 리스트 조회 성공"),
     GET_USER_PROFILE_SUCCESS("USER_200",HttpStatus.OK,"유저 프로필 조회 성공"),
     UPDATE_USER_PROFILE_SUCCESS("USER_200",HttpStatus.OK,"유저 프로필 수정 성공"),
 

--- a/src/main/java/com/roome/roome/be/common/status/SuccessStatus.java
+++ b/src/main/java/com/roome/roome/be/common/status/SuccessStatus.java
@@ -68,7 +68,8 @@ public enum SuccessStatus implements BaseStatus {
      * Reference
      */
     REGISTER_REFERENCE_SUCCESS("REFERENCE_201", HttpStatus.CREATED,"레퍼런스 등록 성공"),
-    REGISTER_REFERENCE_IMAGE_SUCCESS("REFERENCE_201", HttpStatus.CREATED,"레퍼런스 이미지 등록 성공");
+    REGISTER_REFERENCE_IMAGE_SUCCESS("REFERENCE_201", HttpStatus.CREATED,"레퍼런스 이미지 등록 성공"),
+    CREATE_REFERENCE_200_SCRAP("REFERENCE_200", HttpStatus.OK, "레퍼런스 스크랩 토글 성공");
 
     private final String code;
     private final HttpStatus httpStatus;

--- a/src/main/java/com/roome/roome/be/common/status/SuccessStatus.java
+++ b/src/main/java/com/roome/roome/be/common/status/SuccessStatus.java
@@ -36,6 +36,7 @@ public enum SuccessStatus implements BaseStatus {
     SAVE_USER_ONBOARDING("AUTH_201", HttpStatus.CREATED, "유저 온보딩 저장 성공"),
     CHECK_USER_ONBOARDING_EXISTENCE("AUTH_200", HttpStatus.OK, "유저 온보딩 존재 여부 조회 성공"),
     GET_USER_LIKE_PRODUCT_LIST_SUCCESS("USER_200",HttpStatus.OK, "유저 좋아요 상품 리스트 조회 성공"),
+    GET_USER_PROFILE_SUCCESS("USER_200",HttpStatus.OK,"유저 프로필 조회 성공"),
 
     /**
      * Shop

--- a/src/main/java/com/roome/roome/be/common/status/SuccessStatus.java
+++ b/src/main/java/com/roome/roome/be/common/status/SuccessStatus.java
@@ -50,6 +50,7 @@ public enum SuccessStatus implements BaseStatus {
      * S3
      */
     S3_PRESIGNED_ISSUE_SUCCESS("S3_200", HttpStatus.OK, "Presigned URL 발급 성공"),
+    S3_COMMIT_SUCCESS("S3_200",HttpStatus.OK,"S3 이미지 업로드 성공"),
 
     /**
      * Product
@@ -61,7 +62,13 @@ public enum SuccessStatus implements BaseStatus {
     GET_PRODUCT_LIST("PRODUCT_200", HttpStatus.OK, "상품 목록 조회 성공"),
     UPDATE_PRODUCT_SUCCESS("PRODUCT_200", HttpStatus.OK,"상품 수정 성공"),
     UPDATE_PRODUCT_IMAGES_SUCCESS("PRODUCT_200", HttpStatus.OK,"상품 이미지 수정 성공"),
-    DELETE_PRODUCT_SUCCESS("PRODUCT_200", HttpStatus.OK, "상품 삭제 성공");
+    DELETE_PRODUCT_SUCCESS("PRODUCT_200", HttpStatus.OK, "상품 삭제 성공"),
+
+    /**
+     * Reference
+     */
+    REGISTER_REFERENCE_SUCCESS("REFERENCE_201", HttpStatus.CREATED,"레퍼런스 등록 성공"),
+    REGISTER_REFERENCE_IMAGE_SUCCESS("REFERENCE_201", HttpStatus.CREATED,"레퍼런스 이미지 등록 성공");
 
     private final String code;
     private final HttpStatus httpStatus;

--- a/src/main/java/com/roome/roome/be/common/status/SuccessStatus.java
+++ b/src/main/java/com/roome/roome/be/common/status/SuccessStatus.java
@@ -37,6 +37,7 @@ public enum SuccessStatus implements BaseStatus {
     CHECK_USER_ONBOARDING_EXISTENCE("AUTH_200", HttpStatus.OK, "유저 온보딩 존재 여부 조회 성공"),
     GET_USER_LIKE_PRODUCT_LIST_SUCCESS("USER_200",HttpStatus.OK, "유저 좋아요 상품 리스트 조회 성공"),
     GET_USER_PROFILE_SUCCESS("USER_200",HttpStatus.OK,"유저 프로필 조회 성공"),
+    UPDATE_USER_PROFILE_SUCCESS("USER_200",HttpStatus.OK,"유저 프로필 수정 성공"),
 
     /**
      * Shop

--- a/src/main/java/com/roome/roome/be/common/status/SuccessStatus.java
+++ b/src/main/java/com/roome/roome/be/common/status/SuccessStatus.java
@@ -69,7 +69,8 @@ public enum SuccessStatus implements BaseStatus {
      */
     REGISTER_REFERENCE_SUCCESS("REFERENCE_201", HttpStatus.CREATED,"레퍼런스 등록 성공"),
     REGISTER_REFERENCE_IMAGE_SUCCESS("REFERENCE_201", HttpStatus.CREATED,"레퍼런스 이미지 등록 성공"),
-    CREATE_REFERENCE_200_SCRAP("REFERENCE_200", HttpStatus.OK, "레퍼런스 스크랩 토글 성공");
+    CREATE_REFERENCE_SCRAP("REFERENCE_200", HttpStatus.OK, "레퍼런스 스크랩 토글 성공"),
+    GET_REFERENCE_LIST_SUCCESS("REFERENCE_200",HttpStatus.OK,"레퍼런스 리스트 조회 성공");
 
     private final String code;
     private final HttpStatus httpStatus;

--- a/src/main/java/com/roome/roome/be/domain/auth/service/AuthService.java
+++ b/src/main/java/com/roome/roome/be/domain/auth/service/AuthService.java
@@ -45,7 +45,7 @@ public class AuthService {
     // 로그인
     @Transactional
     public EmailLoginResponse login(LoginRequest request) {
-        User user = userService.findUserByEmail(request.email());
+        User user = userService.getUserByEmail(request.email());
         validatePasswordMatch(request.password(), user.getPassword(), PasswordValidationType.LOGIN);
 
         String accessToken = jwtService.generateAccessToken(user);
@@ -58,14 +58,14 @@ public class AuthService {
     // 로그아웃
     @Transactional
     public void logout(Long userId) {
-        User user = userService.findUserById(userId);
+        User user = userService.getUserById(userId);
         userService.clearRefreshToken(user);
     }
 
     // Update Password
     @Transactional
     public void updatePassword(UpdatePasswordRequest request) {
-        User user = userService.findUserByEmail(request.email());
+        User user = userService.getUserByEmail(request.email());
         validatePasswordMatch(request.password(), user.getPassword(), PasswordValidationType.UPDATE);
 
         userService.updatePassword(user, passwordEncoder.encode(request.password()));
@@ -73,7 +73,7 @@ public class AuthService {
 
     // 전화번호로 이메일 찾기
     public FindEmailResponse findEmail(FindEmailRequest request) {
-        User user = userService.findUserByPhoneNumber(request.phoneNumber())
+        User user = userService.getUserByPhoneNumber(request.phoneNumber())
                 .orElseThrow(() -> new GeneralException(ErrorStatus.EMAIL_NOT_FOUND_1));
         return new FindEmailResponse(user.getEmail());
     }
@@ -142,7 +142,7 @@ public class AuthService {
     @Transactional
     public ReissueAccessTokenResponse reissueAccessToken(String refreshToken) {
         var claims = jwtService.validateRefreshToken(refreshToken);
-        User user = userService.findUserByRefreshToken(claims, refreshToken);
+        User user = userService.getUserByRefreshToken(claims, refreshToken);
 
         String newAccessToken = jwtService.generateAccessToken(user);
         String newRefreshToken = jwtService.generateRefreshToken(user);

--- a/src/main/java/com/roome/roome/be/domain/product/controller/ProductController.java
+++ b/src/main/java/com/roome/roome/be/domain/product/controller/ProductController.java
@@ -2,8 +2,6 @@ package com.roome.roome.be.domain.product.controller;
 
 import java.util.List;
 
-import com.roome.roome.be.domain.product.dto.response.ProductToggleLikeResponse;
-import com.roome.roome.be.domain.product.dto.response.ProductToggleScrapResponse;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -132,43 +130,5 @@ public class ProductController {
 	) {
 		var page = productService.getList(shopId, category, colorTags, materialTags, styleTags, featureTags, moodTags, match, keyWord, minPrice, maxPrice, pageable);
 		return ApiResponse.success(SuccessStatus.GET_PRODUCT_LIST, page);
-	}
-
-	// 상품 좋아요 기능 구현
-	@PostMapping("{productId}/like")
-	@Operation(
-			summary = "상품 좋아요 토글",
-			description = "이미 좋아요가 눌려 있으면 취소하고, 눌려 있지 않으면 좋아요를 추가합니다."
-	)
-	@Parameters({
-			@Parameter(name = "productId", description = "좋아요를 누를 상품의 ID", example = "123"),
-	})
-	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "좋아요 토글 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ProductToggleLikeResponse.class)))
-	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "유저가 존재하지 않거나 상품이 존재하지 않음", content = @Content(mediaType = "application/json"))
-	public ResponseEntity<ApiResponse<ProductToggleLikeResponse>> toggleProductLike(
-			@PathVariable("productId") Long productId,
-			@AuthenticationPrincipal Long userId
-	) {
-		ProductToggleLikeResponse response = productService.toggleProductLike(productId, userId);
-		return ApiResponse.success(SuccessStatus.CREATE_PRODUCT_LIKE,response);
-	}
-
-	// 상품 스크랩 기능 구현
-	@PostMapping("/{productId}/scrap")
-	@Operation(
-			summary = "상품 스크랩 토글",
-			description = "이미 스크랩이 되어 있으면 취소하고, 되어 있지 않으면 스크랩에 추가합니다."
-	)
-	@Parameters({
-			@Parameter(name = "productId", description = "스크랩할 상품의 ID", example = "123"),
-	})
-	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "스크랩 토글 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ProductToggleScrapResponse.class)))
-	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "유저가 존재하지 않거나 상품이 존재하지 않음", content = @Content(mediaType = "application/json"))
-	public ResponseEntity<ApiResponse<ProductToggleScrapResponse>> toggleProductScrap(
-			@PathVariable("productId") Long productId,
-			@AuthenticationPrincipal Long userId
-	) {
-		ProductToggleScrapResponse response = productService.toggleProductScrap(productId, userId);
-		return ApiResponse.success(SuccessStatus.CREATE_PRODUCT_LIKE,response);
 	}
 }

--- a/src/main/java/com/roome/roome/be/domain/product/controller/ProductController.java
+++ b/src/main/java/com/roome/roome/be/domain/product/controller/ProductController.java
@@ -154,7 +154,7 @@ public class ProductController {
 	}
 
 	// 상품 스크랩 기능 구현
-	@PostMapping("{productId}/scrap")
+	@PostMapping("/{productId}/scrap")
 	@Operation(
 			summary = "상품 스크랩 토글",
 			description = "이미 스크랩이 되어 있으면 취소하고, 되어 있지 않으면 스크랩에 추가합니다."
@@ -162,7 +162,7 @@ public class ProductController {
 	@Parameters({
 			@Parameter(name = "productId", description = "스크랩할 상품의 ID", example = "123"),
 	})
-	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "스크랩 토글 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ProductToggleLikeResponse.class)))
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "스크랩 토글 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ProductToggleScrapResponse.class)))
 	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "유저가 존재하지 않거나 상품이 존재하지 않음", content = @Content(mediaType = "application/json"))
 	public ResponseEntity<ApiResponse<ProductToggleScrapResponse>> toggleProductScrap(
 			@PathVariable("productId") Long productId,

--- a/src/main/java/com/roome/roome/be/domain/product/service/ProductService.java
+++ b/src/main/java/com/roome/roome/be/domain/product/service/ProductService.java
@@ -11,7 +11,7 @@ import com.roome.roome.be.domain.user.entity.User;
 import com.roome.roome.be.domain.user.entity.UserLike;
 import com.roome.roome.be.domain.user.entity.UserScrapProduct;
 import com.roome.roome.be.domain.user.repository.UserLikeRepository;
-import com.roome.roome.be.domain.user.repository.UserScrapRepository;
+import com.roome.roome.be.domain.user.repository.UserScrapProductRepository;
 import com.roome.roome.be.domain.user.service.UserService;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
@@ -49,7 +49,7 @@ public class ProductService {
 	private final ProductTagRepository productTagRepository;
 
     private final UserLikeRepository userLikeRepository;
-    private final UserScrapRepository userScrapRepository;
+    private final UserScrapProductRepository userScrapProductRepository;
 
     private final ProductTagService productTagService;
     private final ProductImageService productImageService;
@@ -254,17 +254,17 @@ public class ProductService {
 
         boolean scrapped;
 
-        Optional<UserScrapProduct> existing = userScrapRepository.findByUserAndProduct(user, product);
+        Optional<UserScrapProduct> existing = userScrapProductRepository.findByUserAndProduct(user, product);
         if (existing.isEmpty()) {
             UserScrapProduct userScrapProduct = UserScrapProduct.builder()
                     .user(user)
                     .product(product)
                     .build();
-            userScrapRepository.save(userScrapProduct);
+            userScrapProductRepository.save(userScrapProduct);
             scrapped = true;
         }
         else {
-            userScrapRepository.delete(existing.get());
+            userScrapProductRepository.delete(existing.get());
             scrapped = false;
         }
 

--- a/src/main/java/com/roome/roome/be/domain/product/service/ProductService.java
+++ b/src/main/java/com/roome/roome/be/domain/product/service/ProductService.java
@@ -9,7 +9,7 @@ import com.roome.roome.be.domain.product.dto.response.*;
 import com.roome.roome.be.domain.product.enums.TagType;
 import com.roome.roome.be.domain.user.entity.User;
 import com.roome.roome.be.domain.user.entity.UserLike;
-import com.roome.roome.be.domain.user.entity.UserScrap;
+import com.roome.roome.be.domain.user.entity.UserScrapProduct;
 import com.roome.roome.be.domain.user.repository.UserLikeRepository;
 import com.roome.roome.be.domain.user.repository.UserScrapRepository;
 import com.roome.roome.be.domain.user.service.UserService;
@@ -254,13 +254,13 @@ public class ProductService {
 
         boolean scrapped;
 
-        Optional<UserScrap> existing = userScrapRepository.findByUserAndProduct(user, product);
+        Optional<UserScrapProduct> existing = userScrapRepository.findByUserAndProduct(user, product);
         if (existing.isEmpty()) {
-            UserScrap userScrap = UserScrap.builder()
+            UserScrapProduct userScrapProduct = UserScrapProduct.builder()
                     .user(user)
                     .product(product)
                     .build();
-            userScrapRepository.save(userScrap);
+            userScrapRepository.save(userScrapProduct);
             scrapped = true;
         }
         else {

--- a/src/main/java/com/roome/roome/be/domain/product/service/ProductService.java
+++ b/src/main/java/com/roome/roome/be/domain/product/service/ProductService.java
@@ -3,16 +3,10 @@ package com.roome.roome.be.domain.product.service;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import com.roome.roome.be.domain.product.dto.response.*;
 import com.roome.roome.be.domain.product.enums.TagType;
-import com.roome.roome.be.domain.user.entity.User;
-import com.roome.roome.be.domain.user.entity.UserLike;
-import com.roome.roome.be.domain.user.entity.UserScrapProduct;
-import com.roome.roome.be.domain.user.repository.UserLikeRepository;
-import com.roome.roome.be.domain.user.repository.UserScrapProductRepository;
-import com.roome.roome.be.domain.user.service.UserService;
+import com.roome.roome.be.domain.user.service.UserViewService;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -48,14 +42,12 @@ public class ProductService {
 	private final ProductImageRepository productImageRepository;
 	private final ProductTagRepository productTagRepository;
 
-    private final UserLikeRepository userLikeRepository;
-    private final UserScrapProductRepository userScrapProductRepository;
 
     private final ProductTagService productTagService;
     private final ProductImageService productImageService;
     private final S3Service s3Service;
     private final ImageUrlBuilder imageUrlBuilder;
-    private final UserService userService;
+    private final UserViewService userViewService;
 
 	@Value("${storage.defaults.shop-logo}")
 	private String defaultShopLogoUrl;
@@ -84,7 +76,6 @@ public class ProductService {
     // 상품 상세 조회
     @Transactional
     public ProductDetailResponse getDetail(Long productId, Long userId) {
-        User user = userService.findUserById(userId);
         Product product = productRepository.findById(productId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.PRODUCT_NOT_FOUND));
 
@@ -113,7 +104,7 @@ public class ProductService {
 
 		var shop = ShopSummaryResponse.from(product.getShop(), logoUrl);
 
-        userService.registerUserView(product, user);
+        userViewService.registerUserView(product, userId);
 
         return new ProductDetailResponse(
                 product.getId(),
@@ -217,58 +208,6 @@ public class ProductService {
                 }
             }
         });
-    }
-
-    // 상품 좋아요 or 좋아요 취소 기능 구현
-    @Transactional
-    public ProductToggleLikeResponse toggleProductLike(Long productId, Long userId) {
-        Product product = findProductById(productId);
-        User user = userService.findUserById(userId);
-
-        boolean liked;
-
-        Optional<UserLike> existing = userLikeRepository.findByUserAndProduct(user, product);
-        if (existing.isEmpty()) {
-            UserLike userLike = UserLike.builder()
-                    .user(user)
-                    .product(product)
-                    .build();
-            userLikeRepository.save(userLike);
-            liked = true;
-            product.incrementLikeCount();
-        }
-        else {
-            userLikeRepository.delete(existing.get());
-            liked = false;
-            product.decrementLikeCount();
-        }
-
-        return new ProductToggleLikeResponse(liked);
-    }
-
-    // 상품 스크랩 or 스크랩 취소 기능 구현
-    @Transactional
-    public ProductToggleScrapResponse toggleProductScrap(Long productId, Long userId) {
-        Product product = findProductById(productId);
-        User user = userService.findUserById(userId);
-
-        boolean scrapped;
-
-        Optional<UserScrapProduct> existing = userScrapProductRepository.findByUserAndProduct(user, product);
-        if (existing.isEmpty()) {
-            UserScrapProduct userScrapProduct = UserScrapProduct.builder()
-                    .user(user)
-                    .product(product)
-                    .build();
-            userScrapProductRepository.save(userScrapProduct);
-            scrapped = true;
-        }
-        else {
-            userScrapProductRepository.delete(existing.get());
-            scrapped = false;
-        }
-
-        return new ProductToggleScrapResponse(scrapped);
     }
 
     public Product findProductById(Long productId) {

--- a/src/main/java/com/roome/roome/be/domain/reference/controller/ReferenceController.java
+++ b/src/main/java/com/roome/roome/be/domain/reference/controller/ReferenceController.java
@@ -1,0 +1,37 @@
+package com.roome.roome.be.domain.reference.controller;
+
+import com.roome.roome.be.common.response.ApiResponse;
+import com.roome.roome.be.common.status.SuccessStatus;
+import com.roome.roome.be.domain.reference.service.ReferenceService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/references")
+@Tag(name = "Reference")
+public class ReferenceController {
+    private final ReferenceService referenceService;
+
+    @PostMapping(value = "", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(
+            summary = "레퍼런스 업로드",
+            description = "레퍼런스 생성 && 레퍼런스 이미지 등록"
+    )
+    public ResponseEntity<ApiResponse<Void>> createReference(
+            @AuthenticationPrincipal Long userId,
+            @RequestPart("files") List<MultipartFile> files
+    ){
+        referenceService.registerReference(userId,files);
+        return ApiResponse.success(SuccessStatus.REGISTER_REFERENCE_SUCCESS);
+    }
+
+}

--- a/src/main/java/com/roome/roome/be/domain/reference/controller/ReferenceController.java
+++ b/src/main/java/com/roome/roome/be/domain/reference/controller/ReferenceController.java
@@ -2,8 +2,13 @@ package com.roome.roome.be.domain.reference.controller;
 
 import com.roome.roome.be.common.response.ApiResponse;
 import com.roome.roome.be.common.status.SuccessStatus;
+import com.roome.roome.be.domain.reference.dto.response.ReferenceToggleScrapResponse;
 import com.roome.roome.be.domain.reference.service.ReferenceService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
@@ -34,4 +39,21 @@ public class ReferenceController {
         return ApiResponse.success(SuccessStatus.REGISTER_REFERENCE_SUCCESS);
     }
 
+    @PostMapping("/{referenceId}/scrap")
+    @Operation(
+            summary = "레퍼런스 스크랩 토글 ",
+            description = "이미 스크랩이 되어 있으면 취소하고, 되어 있지 않으면 스크랩에 추가합니다."
+    )
+    @Parameters({
+            @Parameter(name = "referenceId", description = "스크랩할 Reference ID", example = "1")
+    })
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "스크랩 토글 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ReferenceToggleScrapResponse.class)))
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "유저가 존재하지 않거나 레퍼런스가 존재하지 않음", content = @Content(mediaType = "application/json"))
+    public ResponseEntity<ApiResponse<ReferenceToggleScrapResponse>> toggleProductScrap(
+            @PathVariable("referenceId") Long referenceId,
+            @AuthenticationPrincipal Long userId
+    ) {
+        ReferenceToggleScrapResponse response = referenceService.toggleReferenceScrap(referenceId, userId);
+        return ApiResponse.success(SuccessStatus.CREATE_REFERENCE_200_SCRAP,response);
+    }
 }

--- a/src/main/java/com/roome/roome/be/domain/reference/controller/ReferenceController.java
+++ b/src/main/java/com/roome/roome/be/domain/reference/controller/ReferenceController.java
@@ -3,11 +3,8 @@ package com.roome.roome.be.domain.reference.controller;
 import com.roome.roome.be.common.response.ApiResponse;
 import com.roome.roome.be.common.status.SuccessStatus;
 import com.roome.roome.be.domain.reference.dto.response.ReferenceListResponse;
-import com.roome.roome.be.domain.reference.dto.response.ReferenceToggleScrapResponse;
 import com.roome.roome.be.domain.reference.service.ReferenceService;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -51,23 +48,5 @@ public class ReferenceController {
     ){
         referenceService.registerReference(userId,files);
         return ApiResponse.success(SuccessStatus.REGISTER_REFERENCE_SUCCESS);
-    }
-
-    @PostMapping("/{referenceId}/scrap")
-    @Operation(
-            summary = "레퍼런스 스크랩 토글 ",
-            description = "이미 스크랩이 되어 있으면 취소하고, 되어 있지 않으면 스크랩에 추가합니다."
-    )
-    @Parameters({
-            @Parameter(name = "referenceId", description = "스크랩할 Reference ID", example = "1")
-    })
-    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "스크랩 토글 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ReferenceToggleScrapResponse.class)))
-    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "유저가 존재하지 않거나 레퍼런스가 존재하지 않음", content = @Content(mediaType = "application/json"))
-    public ResponseEntity<ApiResponse<ReferenceToggleScrapResponse>> toggleProductScrap(
-            @PathVariable("referenceId") Long referenceId,
-            @AuthenticationPrincipal Long userId
-    ) {
-        ReferenceToggleScrapResponse response = referenceService.toggleReferenceScrap(referenceId, userId);
-        return ApiResponse.success(SuccessStatus.CREATE_REFERENCE_SCRAP,response);
     }
 }

--- a/src/main/java/com/roome/roome/be/domain/reference/controller/ReferenceController.java
+++ b/src/main/java/com/roome/roome/be/domain/reference/controller/ReferenceController.java
@@ -2,6 +2,7 @@ package com.roome.roome.be.domain.reference.controller;
 
 import com.roome.roome.be.common.response.ApiResponse;
 import com.roome.roome.be.common.status.SuccessStatus;
+import com.roome.roome.be.domain.reference.dto.response.ReferenceListResponse;
 import com.roome.roome.be.domain.reference.dto.response.ReferenceToggleScrapResponse;
 import com.roome.roome.be.domain.reference.service.ReferenceService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -25,6 +26,19 @@ import java.util.List;
 @Tag(name = "Reference")
 public class ReferenceController {
     private final ReferenceService referenceService;
+
+    @GetMapping("")
+    @Operation(
+            summary = "레퍼런스 리스트 조회",
+            description = "레퍼런스 리스트를 사용자에 맞게 출력합니다."
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "스크랩 내역 리스트 조회 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ReferenceListResponse.class)))
+    public ResponseEntity<ApiResponse<ReferenceListResponse>> getReferenceList(
+      @AuthenticationPrincipal Long userId
+    ){
+        ReferenceListResponse response = referenceService.getReferenceList(userId);
+        return ApiResponse.success(SuccessStatus.GET_REFERENCE_LIST_SUCCESS,response);
+    }
 
     @PostMapping(value = "", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(
@@ -54,6 +68,6 @@ public class ReferenceController {
             @AuthenticationPrincipal Long userId
     ) {
         ReferenceToggleScrapResponse response = referenceService.toggleReferenceScrap(referenceId, userId);
-        return ApiResponse.success(SuccessStatus.CREATE_REFERENCE_200_SCRAP,response);
+        return ApiResponse.success(SuccessStatus.CREATE_REFERENCE_SCRAP,response);
     }
 }

--- a/src/main/java/com/roome/roome/be/domain/reference/dto/request/RegisterReferenceImageListRequest.java
+++ b/src/main/java/com/roome/roome/be/domain/reference/dto/request/RegisterReferenceImageListRequest.java
@@ -1,0 +1,10 @@
+package com.roome.roome.be.domain.reference.dto.request;
+
+
+import java.util.List;
+
+public record RegisterReferenceImageListRequest(
+        Long referenceId,
+        List<String> objectKeys
+) {
+}

--- a/src/main/java/com/roome/roome/be/domain/reference/dto/request/RegisterReferenceRequest.java
+++ b/src/main/java/com/roome/roome/be/domain/reference/dto/request/RegisterReferenceRequest.java
@@ -1,0 +1,10 @@
+package com.roome.roome.be.domain.reference.dto.request;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+public record RegisterReferenceRequest(
+        List<MultipartFile> files
+) {
+}

--- a/src/main/java/com/roome/roome/be/domain/reference/dto/response/CommonReferenceInfo.java
+++ b/src/main/java/com/roome/roome/be/domain/reference/dto/response/CommonReferenceInfo.java
@@ -1,0 +1,12 @@
+package com.roome.roome.be.domain.reference.dto.response;
+
+import java.util.List;
+
+public record CommonReferenceInfo(
+        Long referenceId,
+        String nickname,
+        Long userId,
+        List<String> imageUrlList,
+        Integer scrapCount
+) {
+}

--- a/src/main/java/com/roome/roome/be/domain/reference/dto/response/ReferenceListResponse.java
+++ b/src/main/java/com/roome/roome/be/domain/reference/dto/response/ReferenceListResponse.java
@@ -1,0 +1,8 @@
+package com.roome.roome.be.domain.reference.dto.response;
+
+import java.util.List;
+
+public record ReferenceListResponse(
+    List<CommonReferenceInfo> referenceList
+) {
+}

--- a/src/main/java/com/roome/roome/be/domain/reference/dto/response/ReferenceToggleScrapResponse.java
+++ b/src/main/java/com/roome/roome/be/domain/reference/dto/response/ReferenceToggleScrapResponse.java
@@ -1,0 +1,6 @@
+package com.roome.roome.be.domain.reference.dto.response;
+
+public record ReferenceToggleScrapResponse(
+        boolean scrapped
+) {
+}

--- a/src/main/java/com/roome/roome/be/domain/reference/entity/Reference.java
+++ b/src/main/java/com/roome/roome/be/domain/reference/entity/Reference.java
@@ -1,0 +1,30 @@
+package com.roome.roome.be.domain.reference.entity;
+
+import com.roome.roome.be.common.base.BaseEntity;
+import com.roome.roome.be.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Reference extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "like_count",nullable = false)
+    private Integer likeCount;
+
+    @OneToMany(mappedBy = "reference", fetch = FetchType.LAZY)
+    private List<ReferenceImage> referenceImageList = new ArrayList<>();
+}

--- a/src/main/java/com/roome/roome/be/domain/reference/entity/Reference.java
+++ b/src/main/java/com/roome/roome/be/domain/reference/entity/Reference.java
@@ -22,8 +22,8 @@ public class Reference extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @Column(name = "like_count",nullable = false)
-    private Integer likeCount;
+    @Column(name = "scrap_count",nullable = false)
+    private Integer scrapCount;
 
     @OneToMany(mappedBy = "reference", fetch = FetchType.LAZY)
     private List<ReferenceImage> referenceImageList = new ArrayList<>();

--- a/src/main/java/com/roome/roome/be/domain/reference/entity/ReferenceImage.java
+++ b/src/main/java/com/roome/roome/be/domain/reference/entity/ReferenceImage.java
@@ -1,0 +1,23 @@
+package com.roome.roome.be.domain.reference.entity;
+
+import com.roome.roome.be.common.base.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class ReferenceImage extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "reference_id", nullable = false)
+    private Reference reference;
+
+    @Column(nullable = false, length = 512, unique = true)
+    private String imageUrl;
+}

--- a/src/main/java/com/roome/roome/be/domain/reference/entity/ReferenceImage.java
+++ b/src/main/java/com/roome/roome/be/domain/reference/entity/ReferenceImage.java
@@ -18,6 +18,7 @@ public class ReferenceImage extends BaseEntity {
     @JoinColumn(name = "reference_id", nullable = false)
     private Reference reference;
 
-    @Column(nullable = false, length = 512, unique = true)
-    private String imageUrl;
+    @Column(nullable = false, length = 256, unique = true)
+    private String objectKey;
+
 }

--- a/src/main/java/com/roome/roome/be/domain/reference/repository/ReferenceImageRepository.java
+++ b/src/main/java/com/roome/roome/be/domain/reference/repository/ReferenceImageRepository.java
@@ -1,0 +1,9 @@
+package com.roome.roome.be.domain.reference.repository;
+
+import com.roome.roome.be.domain.reference.entity.ReferenceImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ReferenceImageRepository extends JpaRepository<ReferenceImage, Long> {
+}

--- a/src/main/java/com/roome/roome/be/domain/reference/repository/ReferenceRepository.java
+++ b/src/main/java/com/roome/roome/be/domain/reference/repository/ReferenceRepository.java
@@ -1,0 +1,9 @@
+package com.roome.roome.be.domain.reference.repository;
+
+import com.roome.roome.be.domain.reference.entity.Reference;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ReferenceRepository extends JpaRepository<Reference, Long> {
+}

--- a/src/main/java/com/roome/roome/be/domain/reference/service/ReferenceService.java
+++ b/src/main/java/com/roome/roome/be/domain/reference/service/ReferenceService.java
@@ -1,0 +1,53 @@
+package com.roome.roome.be.domain.reference.service;
+
+import com.roome.roome.be.common.exception.GeneralException;
+import com.roome.roome.be.common.s3.enums.StorageScope;
+import com.roome.roome.be.common.s3.service.S3Service;
+import com.roome.roome.be.common.status.ErrorStatus;
+import com.roome.roome.be.domain.reference.entity.Reference;
+import com.roome.roome.be.domain.reference.entity.ReferenceImage;
+import com.roome.roome.be.domain.reference.repository.ReferenceImageRepository;
+import com.roome.roome.be.domain.reference.repository.ReferenceRepository;
+import com.roome.roome.be.domain.user.entity.User;
+import com.roome.roome.be.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ReferenceService {
+
+    private final ReferenceRepository referenceRepository;
+    private final ReferenceImageRepository referenceImageRepository;
+    private final UserRepository userRepository;
+    private final S3Service s3Service;
+
+    // 레퍼런스 등록
+    public void registerReference(Long userId, List<MultipartFile> images ) {
+
+        if(images == null || images.isEmpty()) return;
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        Reference reference = referenceRepository.save(Reference.builder()
+                .user(user)
+                .likeCount(0)
+                .build());
+        Long referenceId = reference.getId();
+
+        List<ReferenceImage> referenceImageList = images.stream()
+                .map(file -> {
+                    String objectKey = s3Service.uploadObject(StorageScope.REFERENCE, referenceId, file);
+                    return ReferenceImage.builder()
+                            .reference(reference)
+                            .objectKey(objectKey) // 컬럼명 object_key 추천
+                            .build();
+                })
+                .toList();
+        referenceImageRepository.saveAll(referenceImageList);
+    }
+}

--- a/src/main/java/com/roome/roome/be/domain/reference/service/ReferenceService.java
+++ b/src/main/java/com/roome/roome/be/domain/reference/service/ReferenceService.java
@@ -7,13 +7,11 @@ import com.roome.roome.be.common.s3.service.S3Service;
 import com.roome.roome.be.common.status.ErrorStatus;
 import com.roome.roome.be.domain.reference.dto.response.CommonReferenceInfo;
 import com.roome.roome.be.domain.reference.dto.response.ReferenceListResponse;
-import com.roome.roome.be.domain.reference.dto.response.ReferenceToggleScrapResponse;
 import com.roome.roome.be.domain.reference.entity.Reference;
 import com.roome.roome.be.domain.reference.entity.ReferenceImage;
 import com.roome.roome.be.domain.reference.repository.ReferenceImageRepository;
 import com.roome.roome.be.domain.reference.repository.ReferenceRepository;
 import com.roome.roome.be.domain.user.entity.User;
-import com.roome.roome.be.domain.user.entity.UserScrapReference;
 import com.roome.roome.be.domain.user.repository.UserRepository;
 import com.roome.roome.be.domain.user.repository.UserScrapReferenceRepository;
 import lombok.RequiredArgsConstructor;
@@ -22,7 +20,6 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.util.Comparator;
 import java.util.List;
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -60,30 +57,6 @@ public class ReferenceService {
                 })
                 .toList();
         referenceImageRepository.saveAll(referenceImageList);
-    }
-
-    public ReferenceToggleScrapResponse toggleReferenceScrap(Long referenceId, Long userId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
-        Reference reference = findReferenceById(referenceId);
-
-        boolean scrapped;
-
-        Optional<UserScrapReference> existing = userScrapReferenceRepository.findByUserAndReference(user,reference);
-        if (existing.isEmpty()) {
-            UserScrapReference userScrapReference = UserScrapReference.builder()
-                    .user(user)
-                    .reference(reference)
-                    .build();
-            userScrapReferenceRepository.save(userScrapReference);
-            scrapped = true;
-        }
-        else {
-            userScrapReferenceRepository.delete(existing.get());
-            scrapped = false;
-        }
-
-        return new ReferenceToggleScrapResponse(scrapped);
     }
 
     public ReferenceListResponse getReferenceList(Long userId) {

--- a/src/main/java/com/roome/roome/be/domain/reference/service/ReferenceService.java
+++ b/src/main/java/com/roome/roome/be/domain/reference/service/ReferenceService.java
@@ -2,8 +2,11 @@ package com.roome.roome.be.domain.reference.service;
 
 import com.roome.roome.be.common.exception.GeneralException;
 import com.roome.roome.be.common.s3.enums.StorageScope;
+import com.roome.roome.be.common.s3.service.ImageUrlBuilder;
 import com.roome.roome.be.common.s3.service.S3Service;
 import com.roome.roome.be.common.status.ErrorStatus;
+import com.roome.roome.be.domain.reference.dto.response.CommonReferenceInfo;
+import com.roome.roome.be.domain.reference.dto.response.ReferenceListResponse;
 import com.roome.roome.be.domain.reference.dto.response.ReferenceToggleScrapResponse;
 import com.roome.roome.be.domain.reference.entity.Reference;
 import com.roome.roome.be.domain.reference.entity.ReferenceImage;
@@ -17,6 +20,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 
@@ -28,7 +32,9 @@ public class ReferenceService {
     private final ReferenceImageRepository referenceImageRepository;
     private final UserRepository userRepository;
     private final UserScrapReferenceRepository userScrapReferenceRepository;
+
     private final S3Service s3Service;
+    private final ImageUrlBuilder imageUrlBuilder;
 
     // 레퍼런스 등록
     public void registerReference(Long userId, List<MultipartFile> images ) {
@@ -40,7 +46,7 @@ public class ReferenceService {
 
         Reference reference = referenceRepository.save(Reference.builder()
                 .user(user)
-                .likeCount(0)
+                .scrapCount(0)
                 .build());
         Long referenceId = reference.getId();
 
@@ -78,6 +84,35 @@ public class ReferenceService {
         }
 
         return new ReferenceToggleScrapResponse(scrapped);
+    }
+
+    public ReferenceListResponse getReferenceList(Long userId) {
+        // todo => 우선 유저만 불러온 뒤, 레퍼런스 관련 기획이 좀 더 상세화되면 그에 맞게 리스트 조회 기능 구체화, 우선은 좋아요 순으로 전체 레퍼런스 정렬
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        List<Reference> referenceList = referenceRepository.findAll();
+        List<CommonReferenceInfo> commonReferenceInfoList = referenceList.stream()
+                .sorted(Comparator.comparing(Reference::getScrapCount).reversed())
+                .map(
+                reference -> {
+                    List<String> imageUrlList = reference.getReferenceImageList().stream()
+                            .map(refImg -> imageUrlBuilder.build(
+                                    refImg.getObjectKey()
+                            ))
+                            .toList();
+
+                    return new CommonReferenceInfo(
+                            reference.getId(),
+                            reference.getUser().getNickname(),
+                            reference.getUser().getId(),
+                            imageUrlList,
+                            reference.getScrapCount()
+                    );
+                }
+
+        ).toList();
+        return new ReferenceListResponse(commonReferenceInfoList);
     }
 
     public Reference findReferenceById(Long referenceId) {

--- a/src/main/java/com/roome/roome/be/domain/reference/service/ReferenceService.java
+++ b/src/main/java/com/roome/roome/be/domain/reference/service/ReferenceService.java
@@ -4,17 +4,21 @@ import com.roome.roome.be.common.exception.GeneralException;
 import com.roome.roome.be.common.s3.enums.StorageScope;
 import com.roome.roome.be.common.s3.service.S3Service;
 import com.roome.roome.be.common.status.ErrorStatus;
+import com.roome.roome.be.domain.reference.dto.response.ReferenceToggleScrapResponse;
 import com.roome.roome.be.domain.reference.entity.Reference;
 import com.roome.roome.be.domain.reference.entity.ReferenceImage;
 import com.roome.roome.be.domain.reference.repository.ReferenceImageRepository;
 import com.roome.roome.be.domain.reference.repository.ReferenceRepository;
 import com.roome.roome.be.domain.user.entity.User;
+import com.roome.roome.be.domain.user.entity.UserScrapReference;
 import com.roome.roome.be.domain.user.repository.UserRepository;
+import com.roome.roome.be.domain.user.repository.UserScrapReferenceRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -23,6 +27,7 @@ public class ReferenceService {
     private final ReferenceRepository referenceRepository;
     private final ReferenceImageRepository referenceImageRepository;
     private final UserRepository userRepository;
+    private final UserScrapReferenceRepository userScrapReferenceRepository;
     private final S3Service s3Service;
 
     // 레퍼런스 등록
@@ -49,5 +54,34 @@ public class ReferenceService {
                 })
                 .toList();
         referenceImageRepository.saveAll(referenceImageList);
+    }
+
+    public ReferenceToggleScrapResponse toggleReferenceScrap(Long referenceId, Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+        Reference reference = findReferenceById(referenceId);
+
+        boolean scrapped;
+
+        Optional<UserScrapReference> existing = userScrapReferenceRepository.findByUserAndReference(user,reference);
+        if (existing.isEmpty()) {
+            UserScrapReference userScrapReference = UserScrapReference.builder()
+                    .user(user)
+                    .reference(reference)
+                    .build();
+            userScrapReferenceRepository.save(userScrapReference);
+            scrapped = true;
+        }
+        else {
+            userScrapReferenceRepository.delete(existing.get());
+            scrapped = false;
+        }
+
+        return new ReferenceToggleScrapResponse(scrapped);
+    }
+
+    public Reference findReferenceById(Long referenceId) {
+        return referenceRepository.findById(referenceId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.REFERENCE_NOT_FOUND));
     }
 }

--- a/src/main/java/com/roome/roome/be/domain/user/controller/UserController.java
+++ b/src/main/java/com/roome/roome/be/domain/user/controller/UserController.java
@@ -92,15 +92,15 @@ public class UserController {
         return ApiResponse.success(SuccessStatus.GET_USER_SCRAP_PRODUCT_LIST_SUCCESS, response);
     }
 
-//    @GetMapping("/scraps/reference")
-//    @Operation(summary = "유저가 스크랩한 레퍼런스 리스트 조회")
-//    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "스크랩 레퍼런스 내역 리스트 조회 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = UserScrappedReferenceListResponse.class)))
-//    public ResponseEntity<ApiResponse<UserScrappedReferenceListResponse>> getUserScrappedReferenceList(
-//            @AuthenticationPrincipal Long userId
-//    ) {
-//        UserScrappedReferenceListResponse response = userService.getUserScrappedReferenceList(userId);
-//        return ApiResponse.success(SuccessStatus.GET_USER_SCRAP_REFERENCE_LIST_SUCCESS, response);
-//    }
+    @GetMapping("/scraps/reference")
+    @Operation(summary = "유저가 스크랩한 레퍼런스 리스트 조회")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "스크랩 레퍼런스 내역 리스트 조회 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = UserScrappedReferenceListResponse.class)))
+    public ResponseEntity<ApiResponse<UserScrappedReferenceListResponse>> getUserScrappedReferenceList(
+            @AuthenticationPrincipal Long userId
+    ) {
+        UserScrappedReferenceListResponse response = userService.getUserScrappedReferenceList(userId);
+        return ApiResponse.success(SuccessStatus.GET_USER_SCRAP_REFERENCE_LIST_SUCCESS, response);
+    }
 
     @GetMapping("/recent-views")
     @Operation(summary = "유저가 최근 본 상품 리스트 조회")

--- a/src/main/java/com/roome/roome/be/domain/user/controller/UserController.java
+++ b/src/main/java/com/roome/roome/be/domain/user/controller/UserController.java
@@ -2,6 +2,7 @@ package com.roome.roome.be.domain.user.controller;
 
 import com.roome.roome.be.common.response.ApiResponse;
 import com.roome.roome.be.common.status.SuccessStatus;
+import com.roome.roome.be.domain.user.dto.request.UpdateUserProfileRequest;
 import com.roome.roome.be.domain.user.dto.request.UserOnboardingRequest;
 import com.roome.roome.be.domain.user.dto.response.*;
 import com.roome.roome.be.domain.user.service.UserService;
@@ -11,13 +12,10 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -29,14 +27,27 @@ public class UserController {
 
     @GetMapping("/profile")
     @Operation(summary = "유저 프로필 조회", description = "유저 계정 정보 조회")
-    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "좋아요 상품 리스트 조회 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = UserProfileResponse.class)))
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "유저 프로필 조회 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = UserProfileResponse.class)))
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "유저가 존재하지 않음", content = @Content)
     public ResponseEntity<ApiResponse<UserProfileResponse>> getUserProfile(
             @AuthenticationPrincipal Long userId
     ) {
         UserProfileResponse response = userService.getUserProfile(userId);
-        return ApiResponse.success(SuccessStatus.GET_USER_PROFILE_SUCCESS,response);
+        return ApiResponse.success(SuccessStatus.GET_USER_PROFILE_SUCCESS, response);
     }
+
+    @PatchMapping(value = "/profile", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(summary = "유저 프로필 수정", description = "유저 닉네임 또는 프로필 이미지 수정")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "유저 프로필 수정 성공", content = @Content(mediaType = "application/json", schema = @Schema()))
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "유저가 존재하지 않음", content = @Content)
+    public ResponseEntity<ApiResponse<Void>> updateUserProfile(
+            @AuthenticationPrincipal Long userId,
+            @ModelAttribute @Valid @RequestBody UpdateUserProfileRequest request
+    ) {
+        userService.updateUserProfile(userId,request);
+        return ApiResponse.success(SuccessStatus.UPDATE_USER_PROFILE_SUCCESS);
+    }
+
 
     @PostMapping("/onboarding")
     @Operation(summary = "유저 온보딩 정보 저장")
@@ -44,8 +55,8 @@ public class UserController {
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청 데이터", content = @Content)
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "유저가 존재하지 않음", content = @Content)
     public ResponseEntity<ApiResponse<Void>> saveUserOnboarding(
-        @AuthenticationPrincipal Long userId,
-        @Valid @RequestBody UserOnboardingRequest userOnboardingRequest
+            @AuthenticationPrincipal Long userId,
+            @Valid @RequestBody UserOnboardingRequest userOnboardingRequest
     ) {
         userService.saveUserOnboarding(userId, userOnboardingRequest);
         return ApiResponse.success(SuccessStatus.SAVE_USER_ONBOARDING);
@@ -56,7 +67,7 @@ public class UserController {
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "온보딩 존재 여부 조회 성공", content = @Content)
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "유저가 존재하지 않음", content = @Content)
     public ResponseEntity<ApiResponse<UserOnboardingExistResponse>> checkOnboardingExistence(
-        @AuthenticationPrincipal Long userId
+            @AuthenticationPrincipal Long userId
     ) {
         UserOnboardingExistResponse response = userService.checkExistence(userId);
         return ApiResponse.success(SuccessStatus.CHECK_USER_ONBOARDING_EXISTENCE, response);
@@ -67,7 +78,7 @@ public class UserController {
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "좋아요 상품 리스트 조회 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = UserLikeProductListResponse.class)))
     public ResponseEntity<ApiResponse<UserLikeProductListResponse>> getUserLikedProductList(
             @AuthenticationPrincipal Long userId
-    ){
+    ) {
         UserLikeProductListResponse response = userService.getUserLikedProductList(userId);
         return ApiResponse.success(SuccessStatus.GET_USER_LIKE_PRODUCT_LIST_SUCCESS, response);
     }
@@ -77,7 +88,7 @@ public class UserController {
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "스크랩 내역 리스트 조회 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = UserScrappedProductListResponse.class)))
     public ResponseEntity<ApiResponse<UserScrappedProductListResponse>> getUserScrappedProductList(
             @AuthenticationPrincipal Long userId
-    ){
+    ) {
         UserScrappedProductListResponse response = userService.getUserScrappedProductList(userId);
         return ApiResponse.success(SuccessStatus.GET_USER_LIKE_PRODUCT_LIST_SUCCESS, response);
     }
@@ -87,7 +98,7 @@ public class UserController {
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "최근 본 상품 리스트 조회 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = UserRecentViewedProductListResponse.class)))
     public ResponseEntity<ApiResponse<UserRecentViewedProductListResponse>> getUserRecentViewedProductList(
             @AuthenticationPrincipal Long userId
-    ){
+    ) {
         UserRecentViewedProductListResponse response = userService.getUserRecentViewedProductList(userId);
         return ApiResponse.success(SuccessStatus.GET_USER_LIKE_PRODUCT_LIST_SUCCESS, response);
     }

--- a/src/main/java/com/roome/roome/be/domain/user/controller/UserController.java
+++ b/src/main/java/com/roome/roome/be/domain/user/controller/UserController.java
@@ -48,7 +48,6 @@ public class UserController {
         return ApiResponse.success(SuccessStatus.UPDATE_USER_PROFILE_SUCCESS);
     }
 
-
     @PostMapping("/onboarding")
     @Operation(summary = "유저 온보딩 정보 저장")
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "온보딩 정보 저장 성공", content = @Content)
@@ -83,15 +82,25 @@ public class UserController {
         return ApiResponse.success(SuccessStatus.GET_USER_LIKE_PRODUCT_LIST_SUCCESS, response);
     }
 
-    @GetMapping("/scraps")
+    @GetMapping("/scraps/product")
     @Operation(summary = "유저가 스크랩한 상품 리스트 조회")
-    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "스크랩 내역 리스트 조회 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = UserScrappedProductListResponse.class)))
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "스크랩 상품 내역 리스트 조회 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = UserScrappedProductListResponse.class)))
     public ResponseEntity<ApiResponse<UserScrappedProductListResponse>> getUserScrappedProductList(
             @AuthenticationPrincipal Long userId
     ) {
         UserScrappedProductListResponse response = userService.getUserScrappedProductList(userId);
-        return ApiResponse.success(SuccessStatus.GET_USER_LIKE_PRODUCT_LIST_SUCCESS, response);
+        return ApiResponse.success(SuccessStatus.GET_USER_SCRAP_PRODUCT_LIST_SUCCESS, response);
     }
+
+//    @GetMapping("/scraps/reference")
+//    @Operation(summary = "유저가 스크랩한 레퍼런스 리스트 조회")
+//    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "스크랩 레퍼런스 내역 리스트 조회 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = UserScrappedReferenceListResponse.class)))
+//    public ResponseEntity<ApiResponse<UserScrappedReferenceListResponse>> getUserScrappedReferenceList(
+//            @AuthenticationPrincipal Long userId
+//    ) {
+//        UserScrappedReferenceListResponse response = userService.getUserScrappedReferenceList(userId);
+//        return ApiResponse.success(SuccessStatus.GET_USER_SCRAP_REFERENCE_LIST_SUCCESS, response);
+//    }
 
     @GetMapping("/recent-views")
     @Operation(summary = "유저가 최근 본 상품 리스트 조회")

--- a/src/main/java/com/roome/roome/be/domain/user/controller/UserController.java
+++ b/src/main/java/com/roome/roome/be/domain/user/controller/UserController.java
@@ -2,11 +2,16 @@ package com.roome.roome.be.domain.user.controller;
 
 import com.roome.roome.be.common.response.ApiResponse;
 import com.roome.roome.be.common.status.SuccessStatus;
+import com.roome.roome.be.domain.product.dto.response.ProductToggleLikeResponse;
+import com.roome.roome.be.domain.product.dto.response.ProductToggleScrapResponse;
+import com.roome.roome.be.domain.reference.dto.response.ReferenceToggleScrapResponse;
 import com.roome.roome.be.domain.user.dto.request.UpdateUserProfileRequest;
 import com.roome.roome.be.domain.user.dto.request.UserOnboardingRequest;
 import com.roome.roome.be.domain.user.dto.response.*;
-import com.roome.roome.be.domain.user.service.UserService;
+import com.roome.roome.be.domain.user.service.*;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -23,7 +28,11 @@ import org.springframework.web.bind.annotation.*;
 @Tag(name = "User", description = "유저 API")
 public class UserController {
 
+    private final UserLikeService userLikeService;
+    private final UserOnboardingService userOnboardingService;
     private final UserService userService;
+    private final UserScrapService userScrapService;
+    private final UserViewService userViewService;
 
     @GetMapping("/profile")
     @Operation(summary = "유저 프로필 조회", description = "유저 계정 정보 조회")
@@ -57,8 +66,8 @@ public class UserController {
             @AuthenticationPrincipal Long userId,
             @Valid @RequestBody UserOnboardingRequest userOnboardingRequest
     ) {
-        userService.saveUserOnboarding(userId, userOnboardingRequest);
-        return ApiResponse.success(SuccessStatus.SAVE_USER_ONBOARDING);
+        userOnboardingService.saveUserOnboarding(userId, userOnboardingRequest);
+        return ApiResponse.success(SuccessStatus.SAVE_USER_ONBOARDING_SUCCESS);
     }
 
     @GetMapping("/onboarding/existence")
@@ -68,8 +77,27 @@ public class UserController {
     public ResponseEntity<ApiResponse<UserOnboardingExistResponse>> checkOnboardingExistence(
             @AuthenticationPrincipal Long userId
     ) {
-        UserOnboardingExistResponse response = userService.checkExistence(userId);
-        return ApiResponse.success(SuccessStatus.CHECK_USER_ONBOARDING_EXISTENCE, response);
+        UserOnboardingExistResponse response = userOnboardingService.checkExistence(userId);
+        return ApiResponse.success(SuccessStatus.CHECK_USER_ONBOARDING_EXISTENCE_SUCCESS, response);
+    }
+
+    // 상품 좋아요 기능 구현
+    @PostMapping("/likes/{productId}")
+    @Operation(
+            summary = "상품 좋아요 토글",
+            description = "이미 좋아요가 눌려 있으면 취소하고, 눌려 있지 않으면 좋아요를 추가합니다."
+    )
+    @Parameters({
+            @Parameter(name = "productId", description = "좋아요를 누를 상품의 ID", example = "123"),
+    })
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "좋아요 토글 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ProductToggleLikeResponse.class)))
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "유저가 존재하지 않거나 상품이 존재하지 않음", content = @Content(mediaType = "application/json"))
+    public ResponseEntity<ApiResponse<ProductToggleLikeResponse>> toggleProductLike(
+            @PathVariable("productId") Long productId,
+            @AuthenticationPrincipal Long userId
+    ) {
+        ProductToggleLikeResponse response = userLikeService.toggleProductLike(productId, userId);
+        return ApiResponse.success(SuccessStatus.CREATE_PRODUCT_LIKE,response);
     }
 
     @GetMapping("/likes")
@@ -78,8 +106,45 @@ public class UserController {
     public ResponseEntity<ApiResponse<UserLikeProductListResponse>> getUserLikedProductList(
             @AuthenticationPrincipal Long userId
     ) {
-        UserLikeProductListResponse response = userService.getUserLikedProductList(userId);
+        UserLikeProductListResponse response = userLikeService.getUserLikedProductList(userId);
         return ApiResponse.success(SuccessStatus.GET_USER_LIKE_PRODUCT_LIST_SUCCESS, response);
+    }
+
+    // 상품 스크랩 기능 구현
+    @PostMapping("/scraps/{productId}")
+    @Operation(
+            summary = "상품 스크랩 토글",
+            description = "이미 스크랩이 되어 있으면 취소하고, 되어 있지 않으면 스크랩에 추가합니다."
+    )
+    @Parameters({
+            @Parameter(name = "productId", description = "스크랩할 상품의 ID", example = "123"),
+    })
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "스크랩 토글 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ProductToggleScrapResponse.class)))
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "유저가 존재하지 않거나 상품이 존재하지 않음", content = @Content(mediaType = "application/json"))
+    public ResponseEntity<ApiResponse<ProductToggleScrapResponse>> toggleProductScrap(
+            @PathVariable("productId") Long productId,
+            @AuthenticationPrincipal Long userId
+    ) {
+        ProductToggleScrapResponse response = userScrapService.toggleProductScrap(productId, userId);
+        return ApiResponse.success(SuccessStatus.CREATE_PRODUCT_LIKE,response);
+    }
+
+    @PostMapping("/scraps/{referenceId}")
+    @Operation(
+            summary = "레퍼런스 스크랩 토글 ",
+            description = "이미 스크랩이 되어 있으면 취소하고, 되어 있지 않으면 스크랩에 추가합니다."
+    )
+    @Parameters({
+            @Parameter(name = "referenceId", description = "스크랩할 Reference ID", example = "1")
+    })
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "스크랩 토글 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ReferenceToggleScrapResponse.class)))
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "유저가 존재하지 않거나 레퍼런스가 존재하지 않음", content = @Content(mediaType = "application/json"))
+    public ResponseEntity<ApiResponse<ReferenceToggleScrapResponse>> toggleReferenceScrap(
+            @PathVariable("referenceId") Long referenceId,
+            @AuthenticationPrincipal Long userId
+    ) {
+        ReferenceToggleScrapResponse response = userScrapService.toggleReferenceScrap(referenceId, userId);
+        return ApiResponse.success(SuccessStatus.CREATE_REFERENCE_SCRAP,response);
     }
 
     @GetMapping("/scraps/product")
@@ -88,7 +153,7 @@ public class UserController {
     public ResponseEntity<ApiResponse<UserScrappedProductListResponse>> getUserScrappedProductList(
             @AuthenticationPrincipal Long userId
     ) {
-        UserScrappedProductListResponse response = userService.getUserScrappedProductList(userId);
+        UserScrappedProductListResponse response = userScrapService.getUserScrappedProductList(userId);
         return ApiResponse.success(SuccessStatus.GET_USER_SCRAP_PRODUCT_LIST_SUCCESS, response);
     }
 
@@ -98,7 +163,7 @@ public class UserController {
     public ResponseEntity<ApiResponse<UserScrappedReferenceListResponse>> getUserScrappedReferenceList(
             @AuthenticationPrincipal Long userId
     ) {
-        UserScrappedReferenceListResponse response = userService.getUserScrappedReferenceList(userId);
+        UserScrappedReferenceListResponse response = userScrapService.getUserScrappedReferenceList(userId);
         return ApiResponse.success(SuccessStatus.GET_USER_SCRAP_REFERENCE_LIST_SUCCESS, response);
     }
 
@@ -108,7 +173,7 @@ public class UserController {
     public ResponseEntity<ApiResponse<UserRecentViewedProductListResponse>> getUserRecentViewedProductList(
             @AuthenticationPrincipal Long userId
     ) {
-        UserRecentViewedProductListResponse response = userService.getUserRecentViewedProductList(userId);
+        UserRecentViewedProductListResponse response = userViewService.getUserRecentViewedProductList(userId);
         return ApiResponse.success(SuccessStatus.GET_USER_LIKE_PRODUCT_LIST_SUCCESS, response);
     }
 }

--- a/src/main/java/com/roome/roome/be/domain/user/controller/UserController.java
+++ b/src/main/java/com/roome/roome/be/domain/user/controller/UserController.java
@@ -3,10 +3,7 @@ package com.roome.roome.be.domain.user.controller;
 import com.roome.roome.be.common.response.ApiResponse;
 import com.roome.roome.be.common.status.SuccessStatus;
 import com.roome.roome.be.domain.user.dto.request.UserOnboardingRequest;
-import com.roome.roome.be.domain.user.dto.response.UserLikeProductListResponse;
-import com.roome.roome.be.domain.user.dto.response.UserOnboardingExistResponse;
-import com.roome.roome.be.domain.user.dto.response.UserRecentViewedProductListResponse;
-import com.roome.roome.be.domain.user.dto.response.UserScrappedProductListResponse;
+import com.roome.roome.be.domain.user.dto.response.*;
 import com.roome.roome.be.domain.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -29,6 +26,17 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserController {
 
     private final UserService userService;
+
+    @GetMapping("/profile")
+    @Operation(summary = "유저 프로필 조회", description = "유저 계정 정보 조회")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "좋아요 상품 리스트 조회 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = UserProfileResponse.class)))
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "유저가 존재하지 않음", content = @Content)
+    public ResponseEntity<ApiResponse<UserProfileResponse>> getUserProfile(
+            @AuthenticationPrincipal Long userId
+    ) {
+        UserProfileResponse response = userService.getUserProfile(userId);
+        return ApiResponse.success(SuccessStatus.GET_USER_PROFILE_SUCCESS,response);
+    }
 
     @PostMapping("/onboarding")
     @Operation(summary = "유저 온보딩 정보 저장")

--- a/src/main/java/com/roome/roome/be/domain/user/dto/request/UpdateUserProfileRequest.java
+++ b/src/main/java/com/roome/roome/be/domain/user/dto/request/UpdateUserProfileRequest.java
@@ -1,0 +1,9 @@
+package com.roome.roome.be.domain.user.dto.request;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public record UpdateUserProfileRequest(
+        MultipartFile profileImage,
+        String nickname
+) {
+}

--- a/src/main/java/com/roome/roome/be/domain/user/dto/response/UserProfileResponse.java
+++ b/src/main/java/com/roome/roome/be/domain/user/dto/response/UserProfileResponse.java
@@ -1,0 +1,13 @@
+package com.roome.roome.be.domain.user.dto.response;
+
+import java.time.LocalDate;
+
+public record UserProfileResponse(
+        Long userId,
+        String profileImage,
+        String nickname,
+        LocalDate signUpDate,
+        String phoneNumber,
+        String email
+) {
+}

--- a/src/main/java/com/roome/roome/be/domain/user/dto/response/UserScrappedReferenceListResponse.java
+++ b/src/main/java/com/roome/roome/be/domain/user/dto/response/UserScrappedReferenceListResponse.java
@@ -1,0 +1,10 @@
+package com.roome.roome.be.domain.user.dto.response;
+
+import com.roome.roome.be.domain.reference.dto.response.CommonReferenceInfo;
+
+import java.util.List;
+
+public record UserScrappedReferenceListResponse(
+        List<CommonReferenceInfo> userScrapReferenceList
+) {
+}

--- a/src/main/java/com/roome/roome/be/domain/user/entity/User.java
+++ b/src/main/java/com/roome/roome/be/domain/user/entity/User.java
@@ -54,4 +54,11 @@ public class User extends BaseEntity {
         this.password = password;
     }
 
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public void updateProfileImage(String profileImage) {
+        this.profileImage = profileImage;
+    }
 }

--- a/src/main/java/com/roome/roome/be/domain/user/entity/User.java
+++ b/src/main/java/com/roome/roome/be/domain/user/entity/User.java
@@ -35,6 +35,9 @@ public class User extends BaseEntity {
 
     private String refreshToken;
 
+    @Column(length = 512)
+    private String profileImage;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private Role role;

--- a/src/main/java/com/roome/roome/be/domain/user/entity/UserScrapProduct.java
+++ b/src/main/java/com/roome/roome/be/domain/user/entity/UserScrapProduct.java
@@ -21,7 +21,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-public class UserScrap extends BaseEntity {
+public class UserScrapProduct extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/roome/roome/be/domain/user/entity/UserScrapReference.java
+++ b/src/main/java/com/roome/roome/be/domain/user/entity/UserScrapReference.java
@@ -1,0 +1,26 @@
+package com.roome.roome.be.domain.user.entity;
+
+import com.roome.roome.be.common.base.BaseEntity;
+import com.roome.roome.be.domain.reference.entity.Reference;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class UserScrapReference extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "reference_id", nullable = false)
+    private Reference reference;
+}

--- a/src/main/java/com/roome/roome/be/domain/user/repository/UserScrapCustomRepositoryImpl.java
+++ b/src/main/java/com/roome/roome/be/domain/user/repository/UserScrapCustomRepositoryImpl.java
@@ -15,7 +15,7 @@ import static com.roome.roome.be.domain.product.entity.QProduct.product;
 import static com.roome.roome.be.domain.product.entity.QProductImage.productImage;
 import static com.roome.roome.be.domain.product.entity.QProductTag.productTag;
 import static com.roome.roome.be.domain.product.entity.QTag.tag;
-import static com.roome.roome.be.domain.user.entity.QUserScrap.userScrap;
+import static com.roome.roome.be.domain.user.entity.QUserScrapProduct.userScrapProduct;
 
 @Repository
 @RequiredArgsConstructor
@@ -26,13 +26,13 @@ public class UserScrapCustomRepositoryImpl implements UserScrapCustomRepository 
     @Override
     public List<CommonProductInfo> findUserScrappedProductListByUserId(Long userId) {
         return jpaQueryFactory
-                .from(userScrap)
-                .join(userScrap.product, product)
+                .from(userScrapProduct)
+                .join(userScrapProduct.product, product)
                 .leftJoin(product.productImageList, productImage)
                 .leftJoin(product.productTagList, productTag)
                 .leftJoin(productTag.tag, tag)
-                .where(userScrap.user.id.eq(userId))
-                .orderBy(userScrap.updatedAt.desc())
+                .where(userScrapProduct.user.id.eq(userId))
+                .orderBy(userScrapProduct.updatedAt.desc())
                 .transform(
                         groupBy(product.id).list(
                                 Projections.constructor(CommonProductInfo.class,

--- a/src/main/java/com/roome/roome/be/domain/user/repository/UserScrapProductCustomRepository.java
+++ b/src/main/java/com/roome/roome/be/domain/user/repository/UserScrapProductCustomRepository.java
@@ -4,6 +4,6 @@ import com.roome.roome.be.domain.product.dto.response.CommonProductInfo;
 
 import java.util.List;
 
-public interface UserScrapCustomRepository {
+public interface UserScrapProductCustomRepository {
     List<CommonProductInfo> findUserScrappedProductListByUserId(Long userId);
 }

--- a/src/main/java/com/roome/roome/be/domain/user/repository/UserScrapProductCustomRepositoryImpl.java
+++ b/src/main/java/com/roome/roome/be/domain/user/repository/UserScrapProductCustomRepositoryImpl.java
@@ -19,7 +19,7 @@ import static com.roome.roome.be.domain.user.entity.QUserScrapProduct.userScrapP
 
 @Repository
 @RequiredArgsConstructor
-public class UserScrapCustomRepositoryImpl implements UserScrapCustomRepository {
+public class UserScrapProductCustomRepositoryImpl implements UserScrapProductCustomRepository {
 
     private final JPAQueryFactory jpaQueryFactory;
 

--- a/src/main/java/com/roome/roome/be/domain/user/repository/UserScrapProductRepository.java
+++ b/src/main/java/com/roome/roome/be/domain/user/repository/UserScrapProductRepository.java
@@ -7,6 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface UserScrapRepository extends JpaRepository<UserScrapProduct, Long> {
+public interface UserScrapProductRepository extends JpaRepository<UserScrapProduct, Long> {
     Optional<UserScrapProduct> findByUserAndProduct(User user, Product product);
 }

--- a/src/main/java/com/roome/roome/be/domain/user/repository/UserScrapReferenceCustomRepository.java
+++ b/src/main/java/com/roome/roome/be/domain/user/repository/UserScrapReferenceCustomRepository.java
@@ -1,0 +1,9 @@
+package com.roome.roome.be.domain.user.repository;
+
+import com.roome.roome.be.domain.reference.dto.response.CommonReferenceInfo;
+
+import java.util.List;
+
+public interface UserScrapReferenceCustomRepository {
+    List<CommonReferenceInfo> findUserScrappedReferenceListByUserId(Long userId);
+}

--- a/src/main/java/com/roome/roome/be/domain/user/repository/UserScrapReferenceCustomRepositoryImpl.java
+++ b/src/main/java/com/roome/roome/be/domain/user/repository/UserScrapReferenceCustomRepositoryImpl.java
@@ -1,0 +1,43 @@
+package com.roome.roome.be.domain.user.repository;
+
+import com.querydsl.core.group.GroupBy;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.roome.roome.be.domain.reference.dto.response.CommonReferenceInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import static com.querydsl.core.group.GroupBy.groupBy;
+import static com.roome.roome.be.domain.user.entity.QUserScrapReference.userScrapReference;
+import static com.roome.roome.be.domain.reference.entity.QReference.reference;
+import static com.roome.roome.be.domain.reference.entity.QReferenceImage.referenceImage;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class UserScrapReferenceCustomRepositoryImpl implements UserScrapReferenceCustomRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<CommonReferenceInfo> findUserScrappedReferenceListByUserId(Long userId) {
+        return jpaQueryFactory
+                .from(userScrapReference)
+                .join(userScrapReference.reference, reference)
+                .leftJoin(reference.referenceImageList, referenceImage)
+                .where(userScrapReference.user.id.eq(userId))
+                .orderBy(reference.scrapCount.desc())
+                .transform(
+                        groupBy(reference.id).list(
+                                Projections.constructor(CommonReferenceInfo.class,
+                                        reference.id,
+                                        reference.user.nickname,
+                                        reference.user.id,
+                                        GroupBy.list(referenceImage.objectKey),
+                                        reference.scrapCount
+                                )
+                        )
+                );
+    }
+}

--- a/src/main/java/com/roome/roome/be/domain/user/repository/UserScrapReferenceRepository.java
+++ b/src/main/java/com/roome/roome/be/domain/user/repository/UserScrapReferenceRepository.java
@@ -1,0 +1,14 @@
+package com.roome.roome.be.domain.user.repository;
+
+import com.roome.roome.be.domain.reference.entity.Reference;
+import com.roome.roome.be.domain.user.entity.User;
+import com.roome.roome.be.domain.user.entity.UserScrapReference;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserScrapReferenceRepository extends JpaRepository<UserScrapReference, Long> {
+    Optional<UserScrapReference> findByUserAndReference(User user, Reference reference);
+}

--- a/src/main/java/com/roome/roome/be/domain/user/repository/UserScrapRepository.java
+++ b/src/main/java/com/roome/roome/be/domain/user/repository/UserScrapRepository.java
@@ -2,11 +2,11 @@ package com.roome.roome.be.domain.user.repository;
 
 import com.roome.roome.be.domain.product.entity.Product;
 import com.roome.roome.be.domain.user.entity.User;
-import com.roome.roome.be.domain.user.entity.UserScrap;
+import com.roome.roome.be.domain.user.entity.UserScrapProduct;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface UserScrapRepository extends JpaRepository<UserScrap, Long> {
-    Optional<UserScrap> findByUserAndProduct(User user, Product product);
+public interface UserScrapRepository extends JpaRepository<UserScrapProduct, Long> {
+    Optional<UserScrapProduct> findByUserAndProduct(User user, Product product);
 }

--- a/src/main/java/com/roome/roome/be/domain/user/service/UserLikeService.java
+++ b/src/main/java/com/roome/roome/be/domain/user/service/UserLikeService.java
@@ -1,0 +1,62 @@
+package com.roome.roome.be.domain.user.service;
+
+import com.roome.roome.be.domain.product.dto.response.CommonProductInfo;
+import com.roome.roome.be.domain.product.dto.response.ProductToggleLikeResponse;
+import com.roome.roome.be.domain.product.entity.Product;
+import com.roome.roome.be.domain.product.service.ProductService;
+import com.roome.roome.be.domain.user.dto.response.UserLikeProductListResponse;
+import com.roome.roome.be.domain.user.entity.User;
+import com.roome.roome.be.domain.user.entity.UserLike;
+import com.roome.roome.be.domain.user.repository.UserLikeCustomRepository;
+import com.roome.roome.be.domain.user.repository.UserLikeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class UserLikeService {
+
+    private final UserLikeRepository userLikeRepository;
+    private final UserLikeCustomRepository userLikeCustomRepository;
+
+    private final UserService userService;
+    private final ProductService productService;
+
+    // 상품 좋아요 or 좋아요 취소 기능 구현
+    @Transactional
+    public ProductToggleLikeResponse toggleProductLike(Long productId, Long userId) {
+        Product product = productService.findProductById(productId);
+        User user = userService.getUserById(userId);
+
+        boolean liked;
+
+        Optional<UserLike> existing = userLikeRepository.findByUserAndProduct(user, product);
+        if (existing.isEmpty()) {
+            UserLike userLike = UserLike.builder()
+                    .user(user)
+                    .product(product)
+                    .build();
+            userLikeRepository.save(userLike);
+            liked = true;
+            product.incrementLikeCount();
+        }
+        else {
+            userLikeRepository.delete(existing.get());
+            liked = false;
+            product.decrementLikeCount();
+        }
+
+        return new ProductToggleLikeResponse(liked);
+    }
+
+    // 유저가 좋아요를 누른 상품 리스트 조회
+    public UserLikeProductListResponse getUserLikedProductList(Long userId) {
+        List<CommonProductInfo> userLikeProductList = userLikeCustomRepository.findUserLikeProductListByUserId(userId);
+        return new UserLikeProductListResponse(userLikeProductList);
+    }
+
+}

--- a/src/main/java/com/roome/roome/be/domain/user/service/UserOnboardingService.java
+++ b/src/main/java/com/roome/roome/be/domain/user/service/UserOnboardingService.java
@@ -1,0 +1,60 @@
+package com.roome.roome.be.domain.user.service;
+
+import com.roome.roome.be.domain.user.dto.request.UserOnboardingRequest;
+import com.roome.roome.be.domain.user.dto.response.UserOnboardingExistResponse;
+import com.roome.roome.be.domain.user.entity.User;
+import com.roome.roome.be.domain.user.entity.UserOnboarding;
+import com.roome.roome.be.domain.user.repository.UserOnboardingRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserOnboardingService {
+
+    private final UserOnboardingRepository userOnboardingRepository;
+    private final UserService userService;
+
+    // 유저 온보딩 저장
+    @Transactional
+    public void saveUserOnboarding(Long userId, UserOnboardingRequest userOnboardingRequest) {
+        User user = userService.getUserById(userId);
+        userOnboardingRepository.findByUser(user)
+                .ifPresentOrElse(
+                        UserOnboarding -> updateUserOnboarding(UserOnboarding, userOnboardingRequest),
+                        () -> registerUserOnboarding(user, userOnboardingRequest)
+                );
+    }
+
+    // 유저 온보딩 업데이트
+    private void updateUserOnboarding(UserOnboarding userOnboarding, UserOnboardingRequest userOnboardingRequest) {
+        userOnboarding.update(
+                userOnboardingRequest.ageGroup(),
+                userOnboardingRequest.gender(),
+                userOnboardingRequest.moodType(),
+                userOnboardingRequest.spaceType()
+        );
+    }
+
+    // 유저 온보딩 저장
+    private void registerUserOnboarding(User user, UserOnboardingRequest userOnboardingRequest) {
+        UserOnboarding newOnboarding = UserOnboarding.builder()
+                .user(user)
+                .ageGroup(userOnboardingRequest.ageGroup())
+                .gender(userOnboardingRequest.gender())
+                .moodType(userOnboardingRequest.moodType())
+                .spaceType(userOnboardingRequest.spaceType())
+                .build();
+
+        userOnboardingRepository.save(newOnboarding);
+    }
+
+    //유저온보딩 존재 여부
+    public UserOnboardingExistResponse checkExistence(Long userId) {
+        User user = userService.getUserById(userId);
+        boolean exists = userOnboardingRepository.findByUser(user).isPresent();
+
+        return new UserOnboardingExistResponse(exists);
+    }
+}

--- a/src/main/java/com/roome/roome/be/domain/user/service/UserScrapService.java
+++ b/src/main/java/com/roome/roome/be/domain/user/service/UserScrapService.java
@@ -1,0 +1,119 @@
+package com.roome.roome.be.domain.user.service;
+
+import com.roome.roome.be.common.s3.service.ImageUrlBuilder;
+import com.roome.roome.be.domain.product.dto.response.CommonProductInfo;
+import com.roome.roome.be.domain.product.dto.response.ProductToggleScrapResponse;
+import com.roome.roome.be.domain.product.entity.Product;
+import com.roome.roome.be.domain.product.service.ProductService;
+import com.roome.roome.be.domain.reference.dto.response.CommonReferenceInfo;
+import com.roome.roome.be.domain.reference.dto.response.ReferenceToggleScrapResponse;
+import com.roome.roome.be.domain.reference.entity.Reference;
+import com.roome.roome.be.domain.reference.service.ReferenceService;
+import com.roome.roome.be.domain.user.dto.response.UserScrappedProductListResponse;
+import com.roome.roome.be.domain.user.dto.response.UserScrappedReferenceListResponse;
+import com.roome.roome.be.domain.user.entity.User;
+import com.roome.roome.be.domain.user.entity.UserScrapProduct;
+import com.roome.roome.be.domain.user.entity.UserScrapReference;
+import com.roome.roome.be.domain.user.repository.UserScrapProductCustomRepository;
+import com.roome.roome.be.domain.user.repository.UserScrapProductRepository;
+import com.roome.roome.be.domain.user.repository.UserScrapReferenceCustomRepository;
+import com.roome.roome.be.domain.user.repository.UserScrapReferenceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class UserScrapService {
+
+    private final UserScrapProductRepository userScrapProductRepository;
+    private final UserScrapReferenceRepository userScrapReferenceRepository;
+
+    private final UserScrapReferenceCustomRepository scrapReferenceCustomRepository;
+    private final UserScrapProductCustomRepository userScrapProductCustomRepository;
+
+    private final UserService userService;
+    private final ProductService productService;
+    private final ReferenceService referenceService;
+
+    private final ImageUrlBuilder imageUrlBuilder;
+
+    // 상품 스크랩 or 스크랩 취소 기능 구현
+    @Transactional
+    public ProductToggleScrapResponse toggleProductScrap(Long productId, Long userId) {
+        User user = userService.getUserById(userId);
+        Product product = productService.findProductById(productId);
+
+        boolean scrapped;
+
+        Optional<UserScrapProduct> existing = userScrapProductRepository.findByUserAndProduct(user, product);
+        if (existing.isEmpty()) {
+            UserScrapProduct userScrapProduct = UserScrapProduct.builder()
+                    .user(user)
+                    .product(product)
+                    .build();
+            userScrapProductRepository.save(userScrapProduct);
+            scrapped = true;
+        }
+        else {
+            userScrapProductRepository.delete(existing.get());
+            scrapped = false;
+        }
+
+        return new ProductToggleScrapResponse(scrapped);
+    }
+
+    public ReferenceToggleScrapResponse toggleReferenceScrap(Long referenceId, Long userId) {
+        User user = userService.getUserById(userId);
+        Reference reference = referenceService.findReferenceById(referenceId);
+
+        boolean scrapped;
+
+        Optional<UserScrapReference> existing = userScrapReferenceRepository.findByUserAndReference(user,reference);
+        if (existing.isEmpty()) {
+            UserScrapReference userScrapReference = UserScrapReference.builder()
+                    .user(user)
+                    .reference(reference)
+                    .build();
+            userScrapReferenceRepository.save(userScrapReference);
+            scrapped = true;
+        }
+        else {
+            userScrapReferenceRepository.delete(existing.get());
+            scrapped = false;
+        }
+
+        return new ReferenceToggleScrapResponse(scrapped);
+    }
+
+    // 유저가 스크랩한 상품 리스트 조회
+    public UserScrappedProductListResponse getUserScrappedProductList(Long userId) {
+        List<CommonProductInfo> userScrappedProductList = userScrapProductCustomRepository.findUserScrappedProductListByUserId(userId);
+        return new UserScrappedProductListResponse(userScrappedProductList);
+    }
+
+    // 유저가 스크랩한 레퍼런스 리스트 조회
+    public UserScrappedReferenceListResponse getUserScrappedReferenceList(Long userId) {
+
+        List<CommonReferenceInfo> rawList = scrapReferenceCustomRepository
+                .findUserScrappedReferenceListByUserId(userId);
+
+        List<CommonReferenceInfo> finalList = rawList.stream()
+                .map(raw -> new CommonReferenceInfo(
+                        raw.referenceId(),
+                        raw.nickname(),
+                        raw.userId(),
+                        raw.imageUrlList().stream()
+                                .map(imageUrlBuilder::build)
+                                .toList(),
+                        raw.scrapCount()
+                ))
+                .toList();
+
+        return new UserScrappedReferenceListResponse(finalList);
+    }
+
+}

--- a/src/main/java/com/roome/roome/be/domain/user/service/UserService.java
+++ b/src/main/java/com/roome/roome/be/domain/user/service/UserService.java
@@ -10,6 +10,7 @@ import com.roome.roome.be.domain.auth.dto.response.CheckNicknameResponse;
 import com.roome.roome.be.domain.auth.dto.request.SignUpRequest;
 import com.roome.roome.be.domain.product.dto.response.CommonProductInfo;
 import com.roome.roome.be.domain.product.entity.Product;
+import com.roome.roome.be.domain.reference.dto.response.CommonReferenceInfo;
 import com.roome.roome.be.domain.user.dto.request.UpdateUserProfileRequest;
 import com.roome.roome.be.domain.user.dto.request.UserOnboardingRequest;
 import com.roome.roome.be.domain.user.dto.response.*;
@@ -21,6 +22,7 @@ import com.roome.roome.be.domain.user.enums.Role;
 import com.roome.roome.be.domain.user.repository.*;
 import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -30,14 +32,16 @@ import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class UserService {
     private final UserRepository userRepository;
     private final UserOnboardingRepository userOnboardingRepository;
     private final UserViewRepository userViewRepository;
 
     private final UserLikeCustomRepositoryImpl userLikeCustomRepositoryImpl;
-    private final UserScrapProductCustomRepositoryImpl userScrapCustomRepositoryImpl;
+    private final UserScrapProductCustomRepositoryImpl userScrapProductCustomRepositoryImpl;
     private final UserViewCustomRepositoryImpl userViewCustomRepositoryImpl;
+    private final UserScrapReferenceCustomRepositoryImpl scrapReferenceCustomRepositoryImpl;
 
     private final S3Service s3Service;
     private final ImageUrlBuilder imageUrlBuilder;
@@ -66,7 +70,6 @@ public class UserService {
             user.updateProfileImage(imageUrlBuilder.build(objectKey));
         }
     }
-
 
     // 유저 온보딩 저장
     @Transactional
@@ -120,15 +123,32 @@ public class UserService {
 
     // 유저가 스크랩한 상품 리스트 조회
     public UserScrappedProductListResponse getUserScrappedProductList(Long userId) {
-        List<CommonProductInfo> userScrappedProductList = userScrapCustomRepositoryImpl.findUserScrappedProductListByUserId(userId);
+        List<CommonProductInfo> userScrappedProductList = userScrapProductCustomRepositoryImpl.findUserScrappedProductListByUserId(userId);
         return new UserScrappedProductListResponse(userScrappedProductList);
     }
 
-    // 유저가 스크랩한 상품 리스트 조회
-//    public UserScrappedReferenceListResponse getUserScrappedReferenceList(Long userId) {
-//        List<CommonReferenceInfo> userScrappedReferenceList = userScrapCustomRepositoryImpl.findUserScrappedProductListByUserId(userId);
-//        return new UserScrappedProductListResponse(userScrappedProductList);
-//    }
+    // 유저가 스크랩한 레퍼런스 리스트 조회
+    public UserScrappedReferenceListResponse getUserScrappedReferenceList(Long userId) {
+
+        List<CommonReferenceInfo> rawList = scrapReferenceCustomRepositoryImpl
+                .findUserScrappedReferenceListByUserId(userId);
+
+        log.error("중간 점검 {}", rawList);
+        List<CommonReferenceInfo> finalList = rawList.stream()
+                .map(raw -> new CommonReferenceInfo(
+                        raw.referenceId(),
+                        raw.nickname(),
+                        raw.userId(),
+                        raw.imageUrlList().stream()
+                                .map(imageUrlBuilder::build)  // ★ 여기서 URL 변환
+                                .toList(),
+                        raw.scrapCount()
+                ))
+                .toList();
+
+        return new UserScrappedReferenceListResponse(finalList);
+    }
+
 
     // 유저가 최근 본 상품 리스트 조회
     public UserRecentViewedProductListResponse getUserRecentViewedProductList(Long userId) {

--- a/src/main/java/com/roome/roome/be/domain/user/service/UserService.java
+++ b/src/main/java/com/roome/roome/be/domain/user/service/UserService.java
@@ -8,10 +8,7 @@ import com.roome.roome.be.domain.auth.dto.request.SignUpRequest;
 import com.roome.roome.be.domain.product.dto.response.CommonProductInfo;
 import com.roome.roome.be.domain.product.entity.Product;
 import com.roome.roome.be.domain.user.dto.request.UserOnboardingRequest;
-import com.roome.roome.be.domain.user.dto.response.UserLikeProductListResponse;
-import com.roome.roome.be.domain.user.dto.response.UserOnboardingExistResponse;
-import com.roome.roome.be.domain.user.dto.response.UserRecentViewedProductListResponse;
-import com.roome.roome.be.domain.user.dto.response.UserScrappedProductListResponse;
+import com.roome.roome.be.domain.user.dto.response.*;
 import com.roome.roome.be.domain.user.entity.User;
 import com.roome.roome.be.domain.user.entity.UserOnboarding;
 import com.roome.roome.be.domain.user.entity.UserView;
@@ -37,19 +34,31 @@ public class UserService {
     private final UserScrapCustomRepositoryImpl userScrapCustomRepositoryImpl;
     private final UserViewCustomRepositoryImpl userViewCustomRepositoryImpl;
 
+    public UserProfileResponse getUserProfile(Long userId) {
+        User user = findUserById(userId);
+        return new UserProfileResponse(
+                user.getId(),
+                user.getProfileImage(),
+                user.getNickname(),
+                user.getCreatedAt().toLocalDate(),
+                user.getPhoneNumber(),
+                user.getEmail())
+        ;
+    }
+
     // 유저 온보딩 저장
     @Transactional
-    public void saveUserOnboarding(Long userId, UserOnboardingRequest userOnboardingRequest){
+    public void saveUserOnboarding(Long userId, UserOnboardingRequest userOnboardingRequest) {
         User user = findUserById(userId);
         userOnboardingRepository.findByUser(user)
                 .ifPresentOrElse(
                         UserOnboarding -> updateUserOnboarding(UserOnboarding, userOnboardingRequest),
-                        () -> registerUserOnboarding(user,userOnboardingRequest)
+                        () -> registerUserOnboarding(user, userOnboardingRequest)
                 );
     }
 
     // 유저 온보딩 업데이트
-    private void updateUserOnboarding(UserOnboarding userOnboarding, UserOnboardingRequest userOnboardingRequest){
+    private void updateUserOnboarding(UserOnboarding userOnboarding, UserOnboardingRequest userOnboardingRequest) {
         userOnboarding.update(
                 userOnboardingRequest.ageGroup(),
                 userOnboardingRequest.gender(),
@@ -74,7 +83,7 @@ public class UserService {
     //유저온보딩 존재 여부
     public UserOnboardingExistResponse checkExistence(Long userId) {
         User user = userRepository.findById(userId)
-            .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
 
         boolean exists = userOnboardingRepository.findByUser(user).isPresent();
 
@@ -113,7 +122,7 @@ public class UserService {
     }
 
     // 이메일 중복 검사
-    public CheckEmailResponse checkEmail(String email){
+    public CheckEmailResponse checkEmail(String email) {
         boolean isExist = userRepository.existsByEmail(email);
         return new CheckEmailResponse(isExist);
     }
@@ -133,17 +142,16 @@ public class UserService {
     }
 
     // User View 등록
-    public void registerUserView(Product product, User user ){
-        UserView userView = userViewRepository.findByUserAndProduct(user,product);
+    public void registerUserView(Product product, User user) {
+        UserView userView = userViewRepository.findByUserAndProduct(user, product);
 
-        if(userView == null) {
+        if (userView == null) {
             userView = UserView.builder()
                     .user(user)
                     .product(product)
                     .build();
             userViewRepository.save(userView);
-        }
-        else{
+        } else {
             userView.touch();
         }
 

--- a/src/main/java/com/roome/roome/be/domain/user/service/UserService.java
+++ b/src/main/java/com/roome/roome/be/domain/user/service/UserService.java
@@ -8,15 +8,9 @@ import com.roome.roome.be.common.status.ErrorStatus;
 import com.roome.roome.be.domain.auth.dto.response.CheckEmailResponse;
 import com.roome.roome.be.domain.auth.dto.response.CheckNicknameResponse;
 import com.roome.roome.be.domain.auth.dto.request.SignUpRequest;
-import com.roome.roome.be.domain.product.dto.response.CommonProductInfo;
-import com.roome.roome.be.domain.product.entity.Product;
-import com.roome.roome.be.domain.reference.dto.response.CommonReferenceInfo;
 import com.roome.roome.be.domain.user.dto.request.UpdateUserProfileRequest;
-import com.roome.roome.be.domain.user.dto.request.UserOnboardingRequest;
 import com.roome.roome.be.domain.user.dto.response.*;
 import com.roome.roome.be.domain.user.entity.User;
-import com.roome.roome.be.domain.user.entity.UserOnboarding;
-import com.roome.roome.be.domain.user.entity.UserView;
 import com.roome.roome.be.domain.user.enums.LoginType;
 import com.roome.roome.be.domain.user.enums.Role;
 import com.roome.roome.be.domain.user.repository.*;
@@ -27,7 +21,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -35,19 +28,12 @@ import java.util.Optional;
 @Slf4j
 public class UserService {
     private final UserRepository userRepository;
-    private final UserOnboardingRepository userOnboardingRepository;
-    private final UserViewRepository userViewRepository;
-
-    private final UserLikeCustomRepositoryImpl userLikeCustomRepositoryImpl;
-    private final UserScrapProductCustomRepositoryImpl userScrapProductCustomRepositoryImpl;
-    private final UserViewCustomRepositoryImpl userViewCustomRepositoryImpl;
-    private final UserScrapReferenceCustomRepositoryImpl scrapReferenceCustomRepositoryImpl;
 
     private final S3Service s3Service;
     private final ImageUrlBuilder imageUrlBuilder;
 
     public UserProfileResponse getUserProfile(Long userId) {
-        User user = findUserById(userId);
+        User user = getUserById(userId);
         return new UserProfileResponse(
                 user.getId(),
                 user.getProfileImage(),
@@ -59,7 +45,7 @@ public class UserService {
 
     @Transactional
     public void updateUserProfile(Long userId, UpdateUserProfileRequest request){
-        User user = findUserById(userId);
+        User user = getUserById(userId);
 
         if(request.nickname() != null && !request.nickname().isBlank())
             user.updateNickname(request.nickname());
@@ -69,91 +55,6 @@ public class UserService {
             String objectKey = s3Service.uploadObject(StorageScope.USER_PROFILE,userId,file);
             user.updateProfileImage(imageUrlBuilder.build(objectKey));
         }
-    }
-
-    // 유저 온보딩 저장
-    @Transactional
-    public void saveUserOnboarding(Long userId, UserOnboardingRequest userOnboardingRequest) {
-        User user = findUserById(userId);
-        userOnboardingRepository.findByUser(user)
-                .ifPresentOrElse(
-                        UserOnboarding -> updateUserOnboarding(UserOnboarding, userOnboardingRequest),
-                        () -> registerUserOnboarding(user, userOnboardingRequest)
-                );
-    }
-
-    // 유저 온보딩 업데이트
-    private void updateUserOnboarding(UserOnboarding userOnboarding, UserOnboardingRequest userOnboardingRequest) {
-        userOnboarding.update(
-                userOnboardingRequest.ageGroup(),
-                userOnboardingRequest.gender(),
-                userOnboardingRequest.moodType(),
-                userOnboardingRequest.spaceType()
-        );
-    }
-
-    // 유저 온보딩 저장
-    private void registerUserOnboarding(User user, UserOnboardingRequest userOnboardingRequest) {
-        UserOnboarding newOnboarding = UserOnboarding.builder()
-                .user(user)
-                .ageGroup(userOnboardingRequest.ageGroup())
-                .gender(userOnboardingRequest.gender())
-                .moodType(userOnboardingRequest.moodType())
-                .spaceType(userOnboardingRequest.spaceType())
-                .build();
-
-        userOnboardingRepository.save(newOnboarding);
-    }
-
-    //유저온보딩 존재 여부
-    public UserOnboardingExistResponse checkExistence(Long userId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
-
-        boolean exists = userOnboardingRepository.findByUser(user).isPresent();
-
-        return new UserOnboardingExistResponse(exists);
-    }
-
-    // 유저가 좋아요를 누른 상품 리스트 조회
-    public UserLikeProductListResponse getUserLikedProductList(Long userId) {
-        List<CommonProductInfo> userLikeProductList = userLikeCustomRepositoryImpl.findUserLikeProductListByUserId(userId);
-        return new UserLikeProductListResponse(userLikeProductList);
-    }
-
-    // 유저가 스크랩한 상품 리스트 조회
-    public UserScrappedProductListResponse getUserScrappedProductList(Long userId) {
-        List<CommonProductInfo> userScrappedProductList = userScrapProductCustomRepositoryImpl.findUserScrappedProductListByUserId(userId);
-        return new UserScrappedProductListResponse(userScrappedProductList);
-    }
-
-    // 유저가 스크랩한 레퍼런스 리스트 조회
-    public UserScrappedReferenceListResponse getUserScrappedReferenceList(Long userId) {
-
-        List<CommonReferenceInfo> rawList = scrapReferenceCustomRepositoryImpl
-                .findUserScrappedReferenceListByUserId(userId);
-
-        log.error("중간 점검 {}", rawList);
-        List<CommonReferenceInfo> finalList = rawList.stream()
-                .map(raw -> new CommonReferenceInfo(
-                        raw.referenceId(),
-                        raw.nickname(),
-                        raw.userId(),
-                        raw.imageUrlList().stream()
-                                .map(imageUrlBuilder::build)  // ★ 여기서 URL 변환
-                                .toList(),
-                        raw.scrapCount()
-                ))
-                .toList();
-
-        return new UserScrappedReferenceListResponse(finalList);
-    }
-
-
-    // 유저가 최근 본 상품 리스트 조회
-    public UserRecentViewedProductListResponse getUserRecentViewedProductList(Long userId) {
-        List<CommonProductInfo> userRecentViewedProductList = userViewCustomRepositoryImpl.findUserRecentViewedProductListByUserId(userId);
-        return new UserRecentViewedProductListResponse(userRecentViewedProductList);
     }
 
     // 이메일 중복 검사
@@ -189,37 +90,34 @@ public class UserService {
         userRepository.save(user);
     }
 
-    // User View 등록
-    public void registerUserView(Product product, User user) {
-        UserView userView = userViewRepository.findByUserAndProduct(user, product);
-
-        if (userView == null) {
-            userView = UserView.builder()
-                    .user(user)
-                    .product(product)
-                    .build();
-            userViewRepository.save(userView);
-        } else {
-            userView.touch();
-        }
-
-    }
-
     // 이메일로 유저 찾기
-    public User findUserByEmail(String email) {
+    public User getUserByEmail(String email) {
         return userRepository.findByEmail(email)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.EMAIL_NOT_FOUND_2));
     }
 
     // 아이디로 유저 찾기
-    public User findUserById(Long id) {
+    public User getUserById(Long id) {
         return userRepository.findById(id)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
     }
 
     // 전화번호로 유저 찾기
-    public Optional<User> findUserByPhoneNumber(String phoneNumber) {
+    public Optional<User> getUserByPhoneNumber(String phoneNumber) {
         return userRepository.findUserByPhoneNumber(phoneNumber);
+    }
+
+    // RefreshToken으로 User 검색
+    public User getUserByRefreshToken(Claims claims, String refreshToken) {
+        String id = claims.getSubject();
+
+        User user = userRepository.findById(Long.parseLong(id))
+                .orElseThrow(() -> new GeneralException(ErrorStatus.REFRESH_TOKEN_NOT_FOUND));
+
+        if (!refreshToken.equals(user.getRefreshToken())) {
+            throw new GeneralException(ErrorStatus.REFRESH_TOKEN_MISMATCH);
+        }
+        return user;
     }
 
     // RefreshToken 업데이트
@@ -240,19 +138,6 @@ public class UserService {
     // 비밀번호 수정
     public void updatePassword(User user, String encryptedPassword) {
         user.updatePassword(encryptedPassword);
-    }
-
-    // RefreshToken으로 User 검색
-    public User findUserByRefreshToken(Claims claims, String refreshToken) {
-        String id = claims.getSubject();
-
-        User user = userRepository.findById(Long.parseLong(id))
-                .orElseThrow(() -> new GeneralException(ErrorStatus.REFRESH_TOKEN_NOT_FOUND));
-
-        if (!refreshToken.equals(user.getRefreshToken())) {
-            throw new GeneralException(ErrorStatus.REFRESH_TOKEN_MISMATCH);
-        }
-        return user;
     }
 
 }

--- a/src/main/java/com/roome/roome/be/domain/user/service/UserService.java
+++ b/src/main/java/com/roome/roome/be/domain/user/service/UserService.java
@@ -36,7 +36,7 @@ public class UserService {
     private final UserViewRepository userViewRepository;
 
     private final UserLikeCustomRepositoryImpl userLikeCustomRepositoryImpl;
-    private final UserScrapCustomRepositoryImpl userScrapCustomRepositoryImpl;
+    private final UserScrapProductCustomRepositoryImpl userScrapCustomRepositoryImpl;
     private final UserViewCustomRepositoryImpl userViewCustomRepositoryImpl;
 
     private final S3Service s3Service;
@@ -123,6 +123,12 @@ public class UserService {
         List<CommonProductInfo> userScrappedProductList = userScrapCustomRepositoryImpl.findUserScrappedProductListByUserId(userId);
         return new UserScrappedProductListResponse(userScrappedProductList);
     }
+
+    // 유저가 스크랩한 상품 리스트 조회
+//    public UserScrappedReferenceListResponse getUserScrappedReferenceList(Long userId) {
+//        List<CommonReferenceInfo> userScrappedReferenceList = userScrapCustomRepositoryImpl.findUserScrappedProductListByUserId(userId);
+//        return new UserScrappedProductListResponse(userScrappedProductList);
+//    }
 
     // 유저가 최근 본 상품 리스트 조회
     public UserRecentViewedProductListResponse getUserRecentViewedProductList(Long userId) {

--- a/src/main/java/com/roome/roome/be/domain/user/service/UserService.java
+++ b/src/main/java/com/roome/roome/be/domain/user/service/UserService.java
@@ -1,12 +1,16 @@
 package com.roome.roome.be.domain.user.service;
 
 import com.roome.roome.be.common.exception.GeneralException;
+import com.roome.roome.be.common.s3.enums.StorageScope;
+import com.roome.roome.be.common.s3.service.ImageUrlBuilder;
+import com.roome.roome.be.common.s3.service.S3Service;
 import com.roome.roome.be.common.status.ErrorStatus;
 import com.roome.roome.be.domain.auth.dto.response.CheckEmailResponse;
 import com.roome.roome.be.domain.auth.dto.response.CheckNicknameResponse;
 import com.roome.roome.be.domain.auth.dto.request.SignUpRequest;
 import com.roome.roome.be.domain.product.dto.response.CommonProductInfo;
 import com.roome.roome.be.domain.product.entity.Product;
+import com.roome.roome.be.domain.user.dto.request.UpdateUserProfileRequest;
 import com.roome.roome.be.domain.user.dto.request.UserOnboardingRequest;
 import com.roome.roome.be.domain.user.dto.response.*;
 import com.roome.roome.be.domain.user.entity.User;
@@ -19,6 +23,7 @@ import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 import java.util.Optional;
@@ -34,6 +39,9 @@ public class UserService {
     private final UserScrapCustomRepositoryImpl userScrapCustomRepositoryImpl;
     private final UserViewCustomRepositoryImpl userViewCustomRepositoryImpl;
 
+    private final S3Service s3Service;
+    private final ImageUrlBuilder imageUrlBuilder;
+
     public UserProfileResponse getUserProfile(Long userId) {
         User user = findUserById(userId);
         return new UserProfileResponse(
@@ -42,9 +50,23 @@ public class UserService {
                 user.getNickname(),
                 user.getCreatedAt().toLocalDate(),
                 user.getPhoneNumber(),
-                user.getEmail())
-        ;
+                user.getEmail());
     }
+
+    @Transactional
+    public void updateUserProfile(Long userId, UpdateUserProfileRequest request){
+        User user = findUserById(userId);
+
+        if(request.nickname() != null && !request.nickname().isBlank())
+            user.updateNickname(request.nickname());
+
+        MultipartFile file = request.profileImage();
+        if(file != null&& !file.isEmpty()){
+            String objectKey = s3Service.uploadObject(StorageScope.USER_PROFILE,userId,file);
+            user.updateProfileImage(imageUrlBuilder.build(objectKey));
+        }
+    }
+
 
     // 유저 온보딩 저장
     @Transactional

--- a/src/main/java/com/roome/roome/be/domain/user/service/UserViewService.java
+++ b/src/main/java/com/roome/roome/be/domain/user/service/UserViewService.java
@@ -1,0 +1,46 @@
+package com.roome.roome.be.domain.user.service;
+
+import com.roome.roome.be.domain.product.dto.response.CommonProductInfo;
+import com.roome.roome.be.domain.product.entity.Product;
+import com.roome.roome.be.domain.user.dto.response.UserRecentViewedProductListResponse;
+import com.roome.roome.be.domain.user.entity.User;
+import com.roome.roome.be.domain.user.entity.UserView;
+import com.roome.roome.be.domain.user.repository.UserViewCustomRepository;
+import com.roome.roome.be.domain.user.repository.UserViewRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class UserViewService {
+
+    private final UserViewRepository userViewRepository;
+    private final UserViewCustomRepository userViewCustomRepository;
+
+    private final UserService userService;
+
+
+    // 유저가 최근 본 상품 리스트 조회
+    public UserRecentViewedProductListResponse getUserRecentViewedProductList(Long userId) {
+        List<CommonProductInfo> userRecentViewedProductList = userViewCustomRepository.findUserRecentViewedProductListByUserId(userId);
+        return new UserRecentViewedProductListResponse(userRecentViewedProductList);
+    }
+
+    // User View 등록
+    public void registerUserView(Product product, Long userId) {
+        User user = userService.getUserById(userId);
+        UserView userView = userViewRepository.findByUserAndProduct(user, product);
+
+        if (userView == null) {
+            userView = UserView.builder()
+                    .user(user)
+                    .product(product)
+                    .build();
+            userViewRepository.save(userView);
+        } else {
+            userView.touch();
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -27,6 +27,10 @@ spring:
           auth: true
           starttls:
             enable: true
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 100MB
 
 logging:
   level:


### PR DESCRIPTION
## #️⃣ 관련 이슈
closed #41 

## 💡 작업 배경
유저 관련 기능 필요

## 🧩 작업 내용
- [x] 유저 프로필 조회 기능 구현
- [x] 유저 프로필 수정 기능 구현
- [x] 유저가 스크랩한 레퍼런스 리스트 조회 기능 구현
- [x] UserScrap 테이블 -> UserScrapProduct로 이름 수정
- [x] UserService 부분 리팩토링 

## 📸 스크린샷(선택)
<img width="1418" height="910" alt="image" src="https://github.com/user-attachments/assets/995f8030-e53d-4bc3-a1cc-447fbf361969" />
<img width="1420" height="854" alt="image" src="https://github.com/user-attachments/assets/a89d9442-a14b-475b-b3b5-d302bc39b556" />
<img width="1420" height="912" alt="image" src="https://github.com/user-attachments/assets/85fbf362-e03a-4524-aaa4-7df70fe6c53d" />
<img width="1459" height="693" alt="image" src="https://github.com/user-attachments/assets/536e6f88-447e-427e-8e90-a53502bd8491" />


## 📝 기타
- 유저 관련 기능을 구현하였습니다
- UserService가 조금씩 엉키는 것 같아 개발 집중 행사 이후 진행할 리팩토링 전에 간단하게 리팩토링을 하였습니다.
  1. UserService를 UserService, UserLikeService, UserViewService, UserScrapService, UserOnboardingService로 분리(Product 부분에서 서비스들이 분리되어 있어서 이와 같이 통일하고자 함)
  2. 행위의 주체를 User로 보고 스크랩 관련 API들을 UserController로 이관
  3. UserService를 가장 상위의 서비스로 취급하여 UserLikeService같은 하위 서비스에서는 UserService 호출 가능, 그 반대는 성립하지 않도록 코드 구현
