### PR TITLE
[Feat]상품 목록 조회시 유저 좋아요 여부 반환하도록 추가

### DIFF
--- a/src/main/java/com/roome/roome/be/domain/product/controller/ProductController.java
+++ b/src/main/java/com/roome/roome/be/domain/product/controller/ProductController.java
@@ -44,7 +44,7 @@ public class ProductController {
 			@PathVariable Long productId,
 			@AuthenticationPrincipal Long userId
 	) {
-		var dto = productService.getDetail(productId,userId);
+		var dto = productService.getDetail(productId, userId);
 		return ApiResponse.success(SuccessStatus.GET_PRODUCT_DETAIL, dto);
 	}
 
@@ -114,21 +114,24 @@ public class ProductController {
 			@Parameter(name = "size", description = "페이지 크기", example = "20")
 	})
 	public ResponseEntity<ApiResponse<Page<ProductListItemResponse>>> getProducts(
-		@RequestParam(required = false) Long shopId,
-		@RequestParam(required = false) Category category,
-		@RequestParam(required = false, name = "color") List<String> colorTags,
-        @RequestParam(required = false, name = "material") List<String> materialTags,
-		@RequestParam(required = false, name = "style") List<String> styleTags,
-		@RequestParam(required = false, name = "feature") List<String> featureTags,
-		@RequestParam(required = false, name = "mood") List<String> moodTags,
-		@RequestParam(required = false, defaultValue = "any") String match,
-		@RequestParam(required = false) String keyWord,
-		@RequestParam(required = false) Integer minPrice,
-		@RequestParam(required = false) Integer maxPrice,
-		@ParameterObject
-		@PageableDefault(size = 20, sort = "id", direction = Sort.Direction.DESC) Pageable pageable
+			@RequestParam(required = false) Long shopId,
+			@RequestParam(required = false) Category category,
+			@RequestParam(required = false, name = "color") List<String> colorTags,
+			@RequestParam(required = false, name = "material") List<String> materialTags,
+			@RequestParam(required = false, name = "style") List<String> styleTags,
+			@RequestParam(required = false, name = "feature") List<String> featureTags,
+			@RequestParam(required = false, name = "mood") List<String> moodTags,
+			@RequestParam(required = false, defaultValue = "any") String match,
+			@RequestParam(required = false) String keyWord,
+			@RequestParam(required = false) Integer minPrice,
+			@RequestParam(required = false) Integer maxPrice,
+
+			@AuthenticationPrincipal Long userId,
+
+			@ParameterObject
+			@PageableDefault(size = 20, sort = "id", direction = Sort.Direction.DESC) Pageable pageable
 	) {
-		var page = productService.getList(shopId, category, colorTags, materialTags, styleTags, featureTags, moodTags, match, keyWord, minPrice, maxPrice, pageable);
+		var page = productService.getList(shopId, category, colorTags, materialTags, styleTags, featureTags, moodTags, match, keyWord, minPrice, maxPrice, pageable, userId);
 		return ApiResponse.success(SuccessStatus.GET_PRODUCT_LIST, page);
 	}
 }

--- a/src/main/java/com/roome/roome/be/domain/product/dto/response/ProductListItemResponse.java
+++ b/src/main/java/com/roome/roome/be/domain/product/dto/response/ProductListItemResponse.java
@@ -14,9 +14,10 @@ public record ProductListItemResponse(
 	String productUrl,
 	String thumbnailUrl,
 	Long shopId,
-	String shopName
+	String shopName,
+	boolean isLiked
 ) {
-	public static ProductListItemResponse from(Product product, ImageUrlBuilder imageUrlBuilder) {
+	public static ProductListItemResponse from(Product product, ImageUrlBuilder imageUrlBuilder, boolean isLiked) {
 		String category = product.getCategory() != null ? product.getCategory().name() : null;
 		String productUrl = product.getProductUrl() != null ? product.getProductUrl() : null;
 
@@ -28,14 +29,15 @@ public record ProductListItemResponse(
 		String shopName = (product.getShop() != null) ? product.getShop().getName() : null;
 
 		return new ProductListItemResponse(
-			product.getId(),
-			product.getName(),
-			product.getPrice(),
-			category,
-			productUrl,
-			thumbnailUrl,
-			shopId,
-			shopName
+				product.getId(),
+				product.getName(),
+				product.getPrice(),
+				category,
+				productUrl,
+				thumbnailUrl,
+				shopId,
+				shopName,
+				isLiked
 		);
 	}
 }

--- a/src/main/java/com/roome/roome/be/domain/product/service/ProductService.java
+++ b/src/main/java/com/roome/roome/be/domain/product/service/ProductService.java
@@ -1,11 +1,10 @@
 package com.roome.roome.be.domain.product.service;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import com.roome.roome.be.domain.product.dto.response.*;
 import com.roome.roome.be.domain.product.enums.TagType;
+import com.roome.roome.be.domain.user.repository.UserLikeRepository;
 import com.roome.roome.be.domain.user.service.UserViewService;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
@@ -41,6 +40,7 @@ public class ProductService {
 	private final ShopRepository shopRepository;
 	private final ProductImageRepository productImageRepository;
 	private final ProductTagRepository productTagRepository;
+    private final UserLikeRepository userLikeRepository;
 
 
     private final ProductTagService productTagService;
@@ -120,7 +120,7 @@ public class ProductService {
         );
     }
 
-    // 목록 조회
+    // 상품 목록 조회
     @Transactional(readOnly = true)
     public Page<ProductListItemResponse> getList(
             Long shopId,                 // 가게 필터
@@ -134,12 +134,13 @@ public class ProductService {
             String keyWord,
             Integer minPrice,
             Integer maxPrice,
-            Pageable pageable
+            Pageable pageable,
+            Long userId
     ) {
-        // [수정 3] match 문자열 정규화
+        // match 문자열 정규화
         final String normalizedMatch = (match == null) ? "any" : match.trim().toLowerCase();
 
-        // [수정 4] 모든 태그 파라미터를 Map으로 조립
+        // 모든 태그 파라미터를 Map으로 조립
         Map<TagType, List<String>> tagFilters = new HashMap<>();
         if (colorTags != null && !colorTags.isEmpty()) tagFilters.put(TagType.COLOR, colorTags);
         if (materialTags != null && !materialTags.isEmpty()) tagFilters.put(TagType.MATERIAL, materialTags);
@@ -158,8 +159,24 @@ public class ProductService {
                 pageable
         );
 
-        return page.map(p -> ProductListItemResponse.from(p, imageUrlBuilder));
+        Set<Long> likedProductIds = new HashSet<>();
+        if (userId != null && !page.isEmpty()) {
+            List<Long> productIds = page.getContent().stream()
+                    .map(Product::getId)
+                    .toList();
 
+            if (!productIds.isEmpty()) {
+                likedProductIds = userLikeRepository.findLikedProductIds(userId, productIds);
+            }
+        }
+
+        // [수정] map 할 때 likedProductIds에 포함되어 있는지 확인하여 true/false 전달
+        final Set<Long> finalLikedProductIds = likedProductIds;
+        return page.map(p -> ProductListItemResponse.from(
+                p,
+                imageUrlBuilder,
+                finalLikedProductIds.contains(p.getId())
+        ));
     }
 
     // 상품 수정

--- a/src/main/java/com/roome/roome/be/domain/user/repository/UserLikeRepository.java
+++ b/src/main/java/com/roome/roome/be/domain/user/repository/UserLikeRepository.java
@@ -4,9 +4,16 @@ import com.roome.roome.be.domain.product.entity.Product;
 import com.roome.roome.be.domain.user.entity.User;
 import com.roome.roome.be.domain.user.entity.UserLike;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 public interface UserLikeRepository extends JpaRepository<UserLike, Long> {
     public Optional<UserLike> findByUserAndProduct(User user, Product product);
+
+    @Query("SELECT ul.product.id FROM UserLike ul WHERE ul.user.id = :userId AND ul.product.id IN :productIds")
+    Set<Long> findLikedProductIds(@Param("userId") Long userId, @Param("productIds") List<Long> productIds);
 }


### PR DESCRIPTION
## #️⃣ 관련 이슈
closed #46

## 💡 작업 배경

프론트 요청 - 상품 목록 조회시 유저 좋아요 여부 반환하도록 추가

## 🧩 작업 내용
로그인한 사용자가 상품 목록 조회 시, 각 상품에 대해 좋아요를 눌렀는지(isLiked) 여부를 함께 반환하도록 로직을 추가했습니다.
- 상품 목록 isLiked 필드 추가
-  @AuthenticationPrincipal을 통해 로그인한 유저의 ID(userId)를 서비스로 전달하도록 수정

## 📸 스크린샷(선택)
<img width="2882" height="1536" alt="image" src="https://github.com/user-attachments/assets/8e910c69-7ef1-4577-99f1-7e240cbf9995" />

-   좋아요 토글 안 눌렀을 때

<img width="2904" height="1570" alt="image" src="https://github.com/user-attachments/assets/9b408c3b-d632-4599-800e-17f59c6c639e" />

-   좋아요 토글 눌렀을 때

## 📝 기타
