### PR TITLE
[Feat] 상품 상세 정보 조회 세부 기능 추가

### DIFF
--- a/src/main/java/com/roome/roome/be/domain/product/dto/response/ProductDetailResponse.java
+++ b/src/main/java/com/roome/roome/be/domain/product/dto/response/ProductDetailResponse.java
@@ -2,7 +2,9 @@ package com.roome.roome.be.domain.product.dto.response;
 
 import java.util.List;
 
+import com.roome.roome.be.domain.product.entity.Product;
 import com.roome.roome.be.domain.shop.dto.response.ShopSummaryResponse;
+import org.springframework.data.domain.Page;
 
 public record ProductDetailResponse(
 	Long id,
@@ -14,5 +16,29 @@ public record ProductDetailResponse(
 	ShopSummaryResponse shop,
 	String thumbnailUrl,
 	List<ProductImageResponse> images,
-	List<ProductTagResponse> tags
-) {}
+	List<ProductTagResponse> tags,
+	List<RelatedProductResponse> relatedProductList
+) {
+	public static ProductDetailResponse from(
+			Product product,
+			String thumbnailUrl,
+			List<ProductImageResponse> images,
+			List<ProductTagResponse> tags,
+			ShopSummaryResponse shop,
+			List<RelatedProductResponse> relatedProductList
+	) {
+		return new ProductDetailResponse(
+				product.getId(),
+				product.getName(),
+				product.getPrice(),
+				product.getProductUrl(),
+				product.getCategory().name(),
+				product.getDescription(),
+				shop,
+				thumbnailUrl,
+				images,
+				tags,
+				relatedProductList
+		);
+	}
+}

--- a/src/main/java/com/roome/roome/be/domain/product/dto/response/ProductImageResponse.java
+++ b/src/main/java/com/roome/roome/be/domain/product/dto/response/ProductImageResponse.java
@@ -1,8 +1,19 @@
 package com.roome.roome.be.domain.product.dto.response;
 
+import com.roome.roome.be.common.s3.service.ImageUrlBuilder;
+import com.roome.roome.be.domain.product.entity.ProductImage;
+
 public record ProductImageResponse(
 	String objectKey,
 	String url,
 	int sortOrder
-) {}
+) {
+	public static ProductImageResponse from(ProductImage productImage, ImageUrlBuilder imageUrlBuilder) {
+		return new ProductImageResponse(
+				productImage.getObjectKey(),
+				imageUrlBuilder.build(productImage.getObjectKey()),
+				productImage.getSortOrder()
+		);
+	}
+}
 

--- a/src/main/java/com/roome/roome/be/domain/product/dto/response/ProductTagResponse.java
+++ b/src/main/java/com/roome/roome/be/domain/product/dto/response/ProductTagResponse.java
@@ -1,9 +1,18 @@
 package com.roome.roome.be.domain.product.dto.response;
 
+import com.roome.roome.be.domain.product.entity.Tag;
 import com.roome.roome.be.domain.product.enums.TagType;
 
 public record ProductTagResponse(
 	Long id,
 	TagType tagType,
 	String name
-) {}
+) {
+	public static ProductTagResponse from(Tag tag) {
+		return new ProductTagResponse(
+				tag.getId(),
+				tag.getType(),
+				tag.getName()
+		);
+	}
+}

--- a/src/main/java/com/roome/roome/be/domain/product/dto/response/RelatedProductResponse.java
+++ b/src/main/java/com/roome/roome/be/domain/product/dto/response/RelatedProductResponse.java
@@ -1,0 +1,7 @@
+package com.roome.roome.be.domain.product.dto.response;
+
+public record RelatedProductResponse(
+        Long productId,
+        String imageUrl
+) {
+}

--- a/src/main/java/com/roome/roome/be/domain/product/dto/response/RelatedProductResponse.java
+++ b/src/main/java/com/roome/roome/be/domain/product/dto/response/RelatedProductResponse.java
@@ -1,7 +1,13 @@
 package com.roome.roome.be.domain.product.dto.response;
 
+import com.roome.roome.be.domain.product.enums.Category;
+
 public record RelatedProductResponse(
         Long productId,
+        String name,
+        Category category,
+        String description,
+        Integer price,
         String imageUrl
 ) {
 }

--- a/src/main/java/com/roome/roome/be/domain/product/repository/ProductCustomRepository.java
+++ b/src/main/java/com/roome/roome/be/domain/product/repository/ProductCustomRepository.java
@@ -1,5 +1,6 @@
 package com.roome.roome.be.domain.product.repository;
 
+import com.roome.roome.be.domain.product.dto.response.RelatedProductResponse;
 import com.roome.roome.be.domain.product.entity.Product;
 import com.roome.roome.be.domain.product.enums.Category;
 import com.roome.roome.be.domain.product.enums.TagType;
@@ -30,4 +31,11 @@ public interface ProductCustomRepository {
             String match,
             Pageable pageable
     );
+
+    /**
+     *
+     * 상품 상세 정보 조회 시 관련 상품들을 조회
+     */
+    List<RelatedProductResponse> findRelatedProductList(Long excludeProductId, Category category, List<Long> tagIdList);
+
 }

--- a/src/main/java/com/roome/roome/be/domain/product/repository/ProductCustomRepositoryImpl.java
+++ b/src/main/java/com/roome/roome/be/domain/product/repository/ProductCustomRepositoryImpl.java
@@ -1,9 +1,13 @@
 package com.roome.roome.be.domain.product.repository;
 
+import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.roome.roome.be.domain.product.dto.response.RelatedProductResponse;
 import com.roome.roome.be.domain.product.entity.Product;
 import com.roome.roome.be.domain.product.enums.Category;
 import com.roome.roome.be.domain.product.enums.TagType;
@@ -17,13 +21,14 @@ import java.util.Map;
 
 import static com.roome.roome.be.domain.product.entity.QProduct.product;
 import static com.roome.roome.be.domain.product.entity.QProductTag.productTag;
+import static com.roome.roome.be.domain.product.entity.QProductImage.productImage;
 import static com.roome.roome.be.domain.product.entity.QTag.tag;
 import static com.roome.roome.be.domain.shop.entity.QShop.shop;
 
 @RequiredArgsConstructor
 public class ProductCustomRepositoryImpl implements ProductCustomRepository {
 
-    private final JPAQueryFactory queryFactory; // QueryDSL 사용을 위해 주입
+    private final JPAQueryFactory jpaQueryFactory; // QueryDSL 사용을 위해 주입
 
     @Override
     public Page<Product> findByDynamicFilters(
@@ -38,7 +43,7 @@ public class ProductCustomRepositoryImpl implements ProductCustomRepository {
     ) {
 
         // 1. 기본 쿼리 (SELECT p FROM Product p ...)
-        JPAQuery<Product> query = queryFactory
+        JPAQuery<Product> query = jpaQueryFactory
                 .selectFrom(product)
                 .leftJoin(product.shop, shop).fetchJoin() // N+1 방지
                 .distinct();
@@ -62,7 +67,7 @@ public class ProductCustomRepositoryImpl implements ProductCustomRepository {
         List<Product> content = query.fetch();
 
         // 5. Count 쿼리 실행 (페이징을 위해)
-        JPAQuery<Long> countQuery = queryFactory
+        JPAQuery<Long> countQuery = jpaQueryFactory
                 .select(product.countDistinct())
                 .from(product)
                 .where(
@@ -75,6 +80,27 @@ public class ProductCustomRepositoryImpl implements ProductCustomRepository {
                 );
 
         return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+    }
+
+    @Override
+    public List<RelatedProductResponse> findRelatedProductList(Long excludeProductId, Category category, List<Long> tagIdList) {
+
+        NumberExpression<Integer> relevanceScore =
+                buildRelevanceScore(category, tagIdList);
+
+        return jpaQueryFactory.
+                select(Projections.constructor(
+                        RelatedProductResponse.class,
+                        product.id,
+                        productImage.imageUrl
+                ))
+                .from(product)
+                .leftJoin(productImage).on(product.id.eq(productImage.product.id).and(productImage.sortOrder.eq(1)))
+                .leftJoin(productTag).on(product.id.eq(productTag.product.id))
+                .where(product.id.ne(excludeProductId))
+                .orderBy(relevanceScore.desc())
+                .limit(20)
+                .fetch();
     }
 
     private BooleanExpression shopIdEq(Long shopId) {
@@ -127,9 +153,7 @@ public class ProductCustomRepositoryImpl implements ProductCustomRepository {
                 }
             }
             return allMatch;
-        }
-
-        else {
+        } else {
             BooleanExpression anyMatch = null;
             for (Map.Entry<TagType, List<String>> entry : tagFilters.entrySet()) {
                 TagType type = entry.getKey();
@@ -151,4 +175,17 @@ public class ProductCustomRepositoryImpl implements ProductCustomRepository {
             return anyMatch;
         }
     }
+
+    private NumberExpression<Integer> buildRelevanceScore(
+            Category category,
+            List<Long> tagIds
+    ) {
+        return new CaseBuilder()
+                .when(product.category.eq(category)).then(1).otherwise(0)
+                .add(
+                        new CaseBuilder()
+                                .when(productTag.tag.id.in(tagIds)).then(1).otherwise(0)
+                );
+    }
+
 }

--- a/src/main/java/com/roome/roome/be/domain/product/repository/ProductCustomRepositoryImpl.java
+++ b/src/main/java/com/roome/roome/be/domain/product/repository/ProductCustomRepositoryImpl.java
@@ -92,6 +92,10 @@ public class ProductCustomRepositoryImpl implements ProductCustomRepository {
                 select(Projections.constructor(
                         RelatedProductResponse.class,
                         product.id,
+                        product.name,
+                        product.category,
+                        product.description,
+                        product.price,
                         productImage.imageUrl
                 ))
                 .from(product)

--- a/src/main/java/com/roome/roome/be/domain/product/service/ProductService.java
+++ b/src/main/java/com/roome/roome/be/domain/product/service/ProductService.java
@@ -4,6 +4,7 @@ import java.util.*;
 
 import com.roome.roome.be.domain.product.dto.response.*;
 import com.roome.roome.be.domain.product.enums.TagType;
+import com.roome.roome.be.domain.product.repository.ProductCustomRepository;
 import com.roome.roome.be.domain.user.repository.UserLikeRepository;
 import com.roome.roome.be.domain.user.service.UserViewService;
 import org.springframework.beans.factory.annotation.Value;
@@ -36,12 +37,11 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class ProductService {
 
-	private final ProductRepository productRepository;
-	private final ShopRepository shopRepository;
-	private final ProductImageRepository productImageRepository;
-	private final ProductTagRepository productTagRepository;
+    private final ProductRepository productRepository;
+    private final ShopRepository shopRepository;
+    private final ProductImageRepository productImageRepository;
+    private final ProductTagRepository productTagRepository;
     private final UserLikeRepository userLikeRepository;
-
 
     private final ProductTagService productTagService;
     private final ProductImageService productImageService;
@@ -49,21 +49,21 @@ public class ProductService {
     private final ImageUrlBuilder imageUrlBuilder;
     private final UserViewService userViewService;
 
-	@Value("${storage.defaults.shop-logo}")
-	private String defaultShopLogoUrl;
+    @Value("${storage.defaults.shop-logo}")
+    private String defaultShopLogoUrl;
 
-	// 상품 등록
-	@Transactional
-	public Long register(RegisterProductRequest registerProductRequest) {
-		Product product = productRepository.save(Product.builder()
-			.name(registerProductRequest.name())
-			.price(registerProductRequest.price())
-			.category(registerProductRequest.category())
-			.productUrl(registerProductRequest.productUrl())
-			.description(registerProductRequest.description())
-			.shop(shopRepository.findById(registerProductRequest.shopId())
-				.orElseThrow(() -> new GeneralException(ErrorStatus.SHOP_NOT_FOUND)))
-			.build());
+    // 상품 등록
+    @Transactional
+    public Long register(RegisterProductRequest registerProductRequest) {
+        Product product = productRepository.save(Product.builder()
+                .name(registerProductRequest.name())
+                .price(registerProductRequest.price())
+                .category(registerProductRequest.category())
+                .productUrl(registerProductRequest.productUrl())
+                .description(registerProductRequest.description())
+                .shop(shopRepository.findById(registerProductRequest.shopId())
+                        .orElseThrow(() -> new GeneralException(ErrorStatus.SHOP_NOT_FOUND)))
+                .build());
 
         if (registerProductRequest.images() != null) {
             productImageService.commitSessionImages(product.getId(), registerProductRequest.images());
@@ -76,48 +76,49 @@ public class ProductService {
     // 상품 상세 조회
     @Transactional
     public ProductDetailResponse getDetail(Long productId, Long userId) {
-        Product product = productRepository.findById(productId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.PRODUCT_NOT_FOUND));
+        Product product = getProductById(productId);
 
-		var images = productImageRepository.findByProductIdOrderBySortOrder(productId).stream()
-			.map(productImage -> new ProductImageResponse(
-				productImage.getObjectKey(),
-				imageUrlBuilder.build(productImage.getObjectKey()),
-				productImage.getSortOrder()
-			))
-			.toList();
+        // ------------------------------
+        // 1) 대표 이미지 + 상세 이미지
+        // ------------------------------
+        var images = productImageRepository.findByProductIdOrderBySortOrder(productId)
+                .stream()
+                .map(productImage -> ProductImageResponse.from(productImage, imageUrlBuilder))
+                .toList();
 
-		String thumbnailUrl = (product.getThumbnailKey() != null)
-			? imageUrlBuilder.build(product.getThumbnailKey())
-			: (images.isEmpty() ? null : images.get(0).url());
+        String thumbnailUrl = (product.getThumbnailKey() != null)
+                ? imageUrlBuilder.build(product.getThumbnailKey())
+                : (images.isEmpty() ? null : images.get(0).url());
 
-		var tags = productTagRepository.findByProductIdWithTag(productId).stream()
-			.map(productTag -> new ProductTagResponse(
-				productTag.getTag().getId(),
-				productTag.getTag().getType(),
-				productTag.getTag().getName()))
-			.toList();
+        // ------------------------------
+        // 2) 상품 태그
+        // ------------------------------
+        var tags = productTagRepository.findByProductIdWithTag(productId).stream()
+                .map(productTag -> ProductTagResponse.from(productTag.getTag()))
+                .toList();
 
-		String logoUrl = (product.getShop().getLogoObjectKey() != null && !product.getShop().getLogoObjectKey().isBlank())
-			? imageUrlBuilder.build(product.getShop().getLogoObjectKey())
-			: defaultShopLogoUrl;
+        // ------------------------------
+        // 3) Shop 정보
+        // ------------------------------
+        String logoUrl = (product.getShop().getLogoObjectKey() != null && !product.getShop().getLogoObjectKey().isBlank())
+                ? imageUrlBuilder.build(product.getShop().getLogoObjectKey())
+                : defaultShopLogoUrl;
 
-		var shop = ShopSummaryResponse.from(product.getShop(), logoUrl);
-
+        // ------------------------------
+        // 4) 유저 조회 로그 저장
+        // ------------------------------
+        var shop = ShopSummaryResponse.from(product.getShop(), logoUrl);
         userViewService.registerUserView(product, userId);
 
-        return new ProductDetailResponse(
-                product.getId(),
-                product.getName(),
-                product.getPrice(),
-                product.getProductUrl(),
-                product.getCategory().name(),
-                product.getDescription(),
-                shop,
-                thumbnailUrl,
-                images,
-                tags
-        );
+        List<Long> tagIdList = tags.stream().map(ProductTagResponse::id).toList();
+
+        List<RelatedProductResponse> relatedProductList =
+                productRepository.findRelatedProductList(
+                        productId,
+                        product.getCategory(),
+                        tagIdList
+                );
+        return ProductDetailResponse.from(product, thumbnailUrl, images, tags, shop, relatedProductList);
     }
 
     // 상품 목록 조회
@@ -227,7 +228,7 @@ public class ProductService {
         });
     }
 
-    public Product findProductById(Long productId) {
+    public Product getProductById(Long productId) {
         return productRepository.findById(productId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.PRODUCT_NOT_FOUND));
     }

--- a/src/main/java/com/roome/roome/be/domain/product/service/ProductService.java
+++ b/src/main/java/com/roome/roome/be/domain/product/service/ProductService.java
@@ -4,7 +4,6 @@ import java.util.*;
 
 import com.roome.roome.be.domain.product.dto.response.*;
 import com.roome.roome.be.domain.product.enums.TagType;
-import com.roome.roome.be.domain.product.repository.ProductCustomRepository;
 import com.roome.roome.be.domain.user.repository.UserLikeRepository;
 import com.roome.roome.be.domain.user.service.UserViewService;
 import org.springframework.beans.factory.annotation.Value;

--- a/src/main/java/com/roome/roome/be/domain/user/service/UserLikeService.java
+++ b/src/main/java/com/roome/roome/be/domain/user/service/UserLikeService.java
@@ -29,7 +29,7 @@ public class UserLikeService {
     // 상품 좋아요 or 좋아요 취소 기능 구현
     @Transactional
     public ProductToggleLikeResponse toggleProductLike(Long productId, Long userId) {
-        Product product = productService.findProductById(productId);
+        Product product = productService.getProductById(productId);
         User user = userService.getUserById(userId);
 
         boolean liked;

--- a/src/main/java/com/roome/roome/be/domain/user/service/UserScrapService.java
+++ b/src/main/java/com/roome/roome/be/domain/user/service/UserScrapService.java
@@ -45,7 +45,7 @@ public class UserScrapService {
     @Transactional
     public ProductToggleScrapResponse toggleProductScrap(Long productId, Long userId) {
         User user = userService.getUserById(userId);
-        Product product = productService.findProductById(productId);
+        Product product = productService.getProductById(productId);
 
         boolean scrapped;
 


### PR DESCRIPTION
## #️⃣ 관련 이슈
closed #48 

## 💡 작업 배경
- 상품 상세정보 조회 시 관련 상품 리스트 조회 추가

## 🧩 작업 내용
- [x] 상품 상세정보 조회 시 관련 상품 리스트 조회 추가


## 📸 스크린샷(선택)
<img width="1433" height="703" alt="image" src="https://github.com/user-attachments/assets/42e6b5a4-72d9-4832-a91f-68572a4e5076" />



## 📝 기타
- 레퍼런스 쪽에서 이와 같은 기능이 빠져 있는데 시험이 얼마 남지 않아서 시간 날 때 작업할게요 
- 관련 상품 리스트와 관련해서 피그마에 자세히 나와있지 않아서 우선 RelatedProductResponse를 간단하게 작성하였습니다. 후에 기획이 세부화되면 더 추가하겠습니당
  ```
  public record RelatedProductResponse(
          Long productId,
          String name,
          Category category,
          String description,
          Integer price,
          String imageUrl
  ) {
  }