### PR TITLE
[Feat] 댓글 관련 기능 구현

### DIFF
--- a/src/main/java/com/roome/roome/be/common/status/ErrorStatus.java
+++ b/src/main/java/com/roome/roome/be/common/status/ErrorStatus.java
@@ -105,7 +105,8 @@ public enum ErrorStatus implements BaseStatus {
      */
     COMMENT_NOT_FOUND("COMMENT_404", HttpStatus.NOT_FOUND, "존재하지 않는 댓글입니다."),
     COMMENTABLE_ENTITY_NOT_FOUND("COMMENT_404", HttpStatus.NOT_FOUND, "댓글을 달 대상(게시글/상품 등)이 존재하지 않습니다."),
-    COMMENT_AUTHOR_MISMATCH("COMMENT_403", HttpStatus.FORBIDDEN, "댓글 수정/삭제 권한이 없습니다."); // 403 Forbidden
+    COMMENT_AUTHOR_MISMATCH("COMMENT_403", HttpStatus.FORBIDDEN, "댓글 수정/삭제 권한이 없습니다."),
+    COMMENT_CONTENT_TOO_LONG("COMMENT_400", HttpStatus.BAD_REQUEST, "댓글 내용은 최대 200자까지 입력 가능합니다.");
 
     private final String code;
     private final HttpStatus httpStatus;

--- a/src/main/java/com/roome/roome/be/common/status/ErrorStatus.java
+++ b/src/main/java/com/roome/roome/be/common/status/ErrorStatus.java
@@ -98,8 +98,14 @@ public enum ErrorStatus implements BaseStatus {
     /**
      * Reference
      */
-    REFERENCE_NOT_FOUND("REFERENCE_404", HttpStatus.NOT_FOUND, "존재하지 않는 레퍼런스입니다.");
-        
+    REFERENCE_NOT_FOUND("REFERENCE_404", HttpStatus.NOT_FOUND, "존재하지 않는 레퍼런스입니다."),
+
+    /**
+     * Comment
+     */
+    COMMENT_NOT_FOUND("COMMENT_404", HttpStatus.NOT_FOUND, "존재하지 않는 댓글입니다."),
+    COMMENTABLE_ENTITY_NOT_FOUND("COMMENT_404", HttpStatus.NOT_FOUND, "댓글을 달 대상(게시글/상품 등)이 존재하지 않습니다."),
+    COMMENT_AUTHOR_MISMATCH("COMMENT_403", HttpStatus.FORBIDDEN, "댓글 수정/삭제 권한이 없습니다."); // 403 Forbidden
 
     private final String code;
     private final HttpStatus httpStatus;

--- a/src/main/java/com/roome/roome/be/common/status/ErrorStatus.java
+++ b/src/main/java/com/roome/roome/be/common/status/ErrorStatus.java
@@ -106,7 +106,7 @@ public enum ErrorStatus implements BaseStatus {
     COMMENT_NOT_FOUND("COMMENT_404", HttpStatus.NOT_FOUND, "존재하지 않는 댓글입니다."),
     COMMENTABLE_ENTITY_NOT_FOUND("COMMENT_404", HttpStatus.NOT_FOUND, "댓글을 달 대상(게시글/상품 등)이 존재하지 않습니다."),
     COMMENT_AUTHOR_MISMATCH("COMMENT_403", HttpStatus.FORBIDDEN, "댓글 수정/삭제 권한이 없습니다."),
-    COMMENT_CONTENT_TOO_LONG("COMMENT_400", HttpStatus.BAD_REQUEST, "댓글 내용은 최대 200자까지 입력 가능합니다.");
+    COMMENT_CONTENT_TOO_LONG("COMMENT_400", HttpStatus.BAD_REQUEST, "댓글 내용은 최대 400자까지 입력 가능합니다.");
 
     private final String code;
     private final HttpStatus httpStatus;

--- a/src/main/java/com/roome/roome/be/common/status/SuccessStatus.java
+++ b/src/main/java/com/roome/roome/be/common/status/SuccessStatus.java
@@ -83,7 +83,17 @@ public enum SuccessStatus implements BaseStatus {
     REGISTER_REFERENCE_SUCCESS("REFERENCE_201", HttpStatus.CREATED,"레퍼런스 등록 성공"),
     REGISTER_REFERENCE_IMAGE_SUCCESS("REFERENCE_201", HttpStatus.CREATED,"레퍼런스 이미지 등록 성공"),
     CREATE_REFERENCE_SCRAP("REFERENCE_200", HttpStatus.OK, "레퍼런스 스크랩 토글 성공"),
-    GET_REFERENCE_LIST_SUCCESS("REFERENCE_200",HttpStatus.OK,"레퍼런스 리스트 조회 성공");
+    GET_REFERENCE_LIST_SUCCESS("REFERENCE_200",HttpStatus.OK,"레퍼런스 리스트 조회 성공"),
+
+    /**
+     * Comment
+     */
+    CREATE_COMMENT_SUCCESS("COMMENT_201", HttpStatus.CREATED, "댓글 생성 성공"),
+    GET_COMMENT_LIST_SUCCESS("COMMENT_200", HttpStatus.OK, "댓글 목록 조회 성공"),
+    UPDATE_COMMENT_SUCCESS("COMMENT_200", HttpStatus.OK, "댓글 수정 성공"),
+    DELETE_COMMENT_SUCCESS("COMMENT_200", HttpStatus.OK, "댓글 삭제 성공"),
+    TOGGLE_COMMENT_LIKE_SUCCESS("COMMENT_200", HttpStatus.OK, "댓글 좋아요 토글 성공");
+
 
     private final String code;
     private final HttpStatus httpStatus;

--- a/src/main/java/com/roome/roome/be/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/roome/roome/be/domain/comment/controller/CommentController.java
@@ -19,7 +19,17 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.DeleteMapping;
+
 
 import java.util.List;
 

--- a/src/main/java/com/roome/roome/be/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/roome/roome/be/domain/comment/controller/CommentController.java
@@ -99,7 +99,7 @@ public class CommentController {
         return ApiResponse.success(SuccessStatus.DELETE_COMMENT_SUCCESS);
     }
 
-    @PostMapping("/{commentId}/like")
+    @PostMapping("likes/{commentId}")
     @Operation(summary = "댓글 좋아요 토글", description = "댓글에 좋아요를 추가하거나 취소합니다.")
     @Parameters({
             @Parameter(name = "commentId", description = "좋아요를 토글할 댓글의 ID", example = "456"),

--- a/src/main/java/com/roome/roome/be/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/roome/roome/be/domain/comment/controller/CommentController.java
@@ -1,0 +1,106 @@
+package com.roome.roome.be.domain.comment.controller;
+
+import com.roome.roome.be.common.response.ApiResponse;
+import com.roome.roome.be.common.status.SuccessStatus;
+import com.roome.roome.be.domain.comment.dto.request.CommentRequest;
+import com.roome.roome.be.domain.comment.dto.request.CommentUpdateRequest;
+import com.roome.roome.be.domain.comment.dto.response.CommentResponse;
+import com.roome.roome.be.domain.comment.enums.CommentableType;
+import com.roome.roome.be.domain.comment.service.CommentCoreService;
+import com.roome.roome.be.domain.comment.service.CommentLikeService;
+import com.roome.roome.be.domain.comment.service.CommentReadService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/comment") // 댓글 전용 경로
+@Tag(name = "Comment", description = "댓글 API")
+public class CommentController {
+
+    private final CommentCoreService commentCoreService;
+    private final CommentReadService commentReadService;
+    private final CommentLikeService commentLikeService;
+
+    @PostMapping("")
+    @Operation(summary = "댓글 생성", description = "게시글 또는 다른 댓글에 대한 새로운 댓글/대댓글을 생성합니다.")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "댓글 생성 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = CommentResponse.class)))
+    public ResponseEntity<ApiResponse<CommentResponse>> createComment(
+            @AuthenticationPrincipal Long userId,
+            @RequestBody @Valid CommentRequest requestDto
+    ) {
+        CommentResponse response = commentCoreService.createComment(userId, requestDto);
+        return ApiResponse.success(SuccessStatus.CREATE_COMMENT_SUCCESS, response);
+    }
+
+    @GetMapping("")
+    @Operation(summary = "댓글 목록 조회", description = "특정 대상(상품, 레퍼런스 등)에 달린 부모 댓글과 대댓글 목록을 최적화된 방식으로 조회합니다.")
+    @Parameters({
+            @Parameter(name = "type", description = "댓글 대상의 타입 (PRODUCT, REFERENCE 등)", required = true, example = "PRODUCT"),
+            @Parameter(name = "commentableId", description = "댓글 대상의 ID", required = true, example = "123")
+    })
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "댓글 목록 조회 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = CommentResponse.class)))
+    public ResponseEntity<ApiResponse<List<CommentResponse>>> getComments(
+            @AuthenticationPrincipal Long userId,
+            @RequestParam CommentableType type,
+            @RequestParam Long commentableId
+    ) {
+        List<CommentResponse> comments = commentReadService.getComments(userId, type, commentableId);
+        return ApiResponse.success(SuccessStatus.GET_COMMENT_LIST_SUCCESS, comments);
+    }
+
+    @PatchMapping("/{commentId}")
+    @Operation(summary = "댓글 수정", description = "특정 댓글의 내용을 수정합니다.")
+    @Parameters({
+            @Parameter(name = "commentId", description = "수정할 댓글의 ID", example = "456"),
+    })
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "댓글 수정 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = CommentResponse.class)))
+    public ResponseEntity<ApiResponse<CommentResponse>> updateComment(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long commentId,
+            @RequestBody @Valid CommentUpdateRequest updateDto
+    ) {
+        CommentResponse response = commentCoreService.updateComment(userId, commentId, updateDto);
+        return ApiResponse.success(SuccessStatus.UPDATE_COMMENT_SUCCESS, response);
+    }
+
+    @DeleteMapping("/{commentId}")
+    @Operation(summary = "댓글 삭제", description = "자신의 댓글을 삭제합니다.")
+    @Parameters({
+            @Parameter(name = "commentId", description = "삭제할 댓글의 ID", example = "456"),
+    })
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "댓글 삭제 성공 (본문 없음)")
+    public ResponseEntity<ApiResponse<Void>> deleteComment(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long commentId
+    ) {
+        commentCoreService.deleteComment(userId, commentId);
+        return ApiResponse.success(SuccessStatus.DELETE_COMMENT_SUCCESS);
+    }
+
+    @PostMapping("/{commentId}/like")
+    @Operation(summary = "댓글 좋아요 토글", description = "댓글에 좋아요를 추가하거나 취소합니다.")
+    @Parameters({
+            @Parameter(name = "commentId", description = "좋아요를 토글할 댓글의 ID", example = "456"),
+    })
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "좋아요 토글 성공 (본문 없음)")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "유저나 댓글을 찾을 수 없음")
+    public ResponseEntity<ApiResponse<Void>> toggleLike(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long commentId
+    ) {
+        commentLikeService.toggleLike(userId, commentId);
+        return ApiResponse.success(SuccessStatus.TOGGLE_COMMENT_LIKE_SUCCESS);
+    }
+}

--- a/src/main/java/com/roome/roome/be/domain/comment/converter/CommentConverter.java
+++ b/src/main/java/com/roome/roome/be/domain/comment/converter/CommentConverter.java
@@ -1,0 +1,60 @@
+package com.roome.roome.be.domain.comment.converter;
+
+import com.roome.roome.be.domain.comment.dto.request.CommentRequest;
+import com.roome.roome.be.domain.comment.dto.response.CommentResponse;
+import com.roome.roome.be.domain.comment.entity.Comment;
+import com.roome.roome.be.domain.user.entity.User;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class CommentConverter {
+
+    public Comment toEntity(CommentRequest requestDto, User user, Comment parentComment) {
+        return Comment.builder()
+                .user(user)
+                .parentComment(parentComment)
+                .commentableType(requestDto.getCommentableType())
+                .commentableId(requestDto.getCommentableId())
+                .content(requestDto.getContent())
+                .likeCount(0)
+                .build();
+    }
+
+    public CommentResponse toDto(Comment comment, Long currentUserId, boolean isLiked) {
+        return CommentResponse.builder()
+                .id(comment.getId())
+                .userId(comment.getUser().getId())
+                .nickname(comment.getUser().getNickname())
+                .profileImage(comment.getUser().getProfileImage())
+                .content(comment.getContent())
+                .likeCount(comment.getLikeCount())
+                .isLiked(isLiked)
+                .isAuthor(comment.getUser().getId().equals(currentUserId))
+                .createdAt(comment.getCreatedAt())
+                .updatedAt(comment.getUpdatedAt())
+                .build();
+    }
+
+    public CommentResponse toDtoWithChildren(
+            Comment parent,
+            Long currentUserId,
+            boolean isLiked,
+            List<CommentResponse> childResponses) {
+
+        return CommentResponse.builder()
+                .id(parent.getId())
+                .userId(parent.getUser().getId())
+                .nickname(parent.getUser().getNickname())
+                .profileImage(parent.getUser().getProfileImage())
+                .content(parent.getContent())
+                .likeCount(parent.getLikeCount())
+                .isLiked(isLiked)
+                .isAuthor(parent.getUser().getId().equals(currentUserId))
+                .createdAt(parent.getCreatedAt())
+                .updatedAt(parent.getUpdatedAt())
+                .childComments(childResponses)
+                .build();
+    }
+}

--- a/src/main/java/com/roome/roome/be/domain/comment/dto/request/CommentRequest.java
+++ b/src/main/java/com/roome/roome/be/domain/comment/dto/request/CommentRequest.java
@@ -22,7 +22,7 @@ public class CommentRequest {
     private Long commentableId;
 
     @NotBlank(message = "댓글 내용은 필수입니다.")
-    @Size(max = 200, message = "댓글 내용은 최대 200자까지 입력 가능합니다.")
+    @Size(max = 400, message = "댓글 내용은 최대 400자까지 입력 가능합니다.")
     private String content;
 
     private Long parentCommentId;

--- a/src/main/java/com/roome/roome/be/domain/comment/dto/request/CommentRequest.java
+++ b/src/main/java/com/roome/roome/be/domain/comment/dto/request/CommentRequest.java
@@ -1,0 +1,27 @@
+package com.roome.roome.be.domain.comment.dto.request;
+
+import com.roome.roome.be.domain.comment.enums.CommentableType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CommentRequest {
+
+    @NotNull(message = "댓글 대상 타입은 필수입니다.")
+    private CommentableType commentableType;
+
+    @NotNull(message = "댓글 대상 ID는 필수입니다.")
+    private Long commentableId;
+
+    @NotBlank(message = "댓글 내용은 필수입니다.")
+    private String content;
+
+    private Long parentCommentId;
+}

--- a/src/main/java/com/roome/roome/be/domain/comment/dto/request/CommentRequest.java
+++ b/src/main/java/com/roome/roome/be/domain/comment/dto/request/CommentRequest.java
@@ -3,6 +3,7 @@ package com.roome.roome.be.domain.comment.dto.request;
 import com.roome.roome.be.domain.comment.enums.CommentableType;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -21,6 +22,7 @@ public class CommentRequest {
     private Long commentableId;
 
     @NotBlank(message = "댓글 내용은 필수입니다.")
+    @Size(max = 200, message = "댓글 내용은 최대 200자까지 입력 가능합니다.")
     private String content;
 
     private Long parentCommentId;

--- a/src/main/java/com/roome/roome/be/domain/comment/dto/request/CommentUpdateRequest.java
+++ b/src/main/java/com/roome/roome/be/domain/comment/dto/request/CommentUpdateRequest.java
@@ -1,0 +1,16 @@
+package com.roome.roome.be.domain.comment.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+
+public class CommentUpdateRequest {
+
+    @NotBlank(message = "댓글 내용은 필수입니다.")
+    private String content;
+}

--- a/src/main/java/com/roome/roome/be/domain/comment/dto/request/CommentUpdateRequest.java
+++ b/src/main/java/com/roome/roome/be/domain/comment/dto/request/CommentUpdateRequest.java
@@ -1,6 +1,7 @@
 package com.roome.roome.be.domain.comment.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,5 +13,6 @@ import lombok.NoArgsConstructor;
 public class CommentUpdateRequest {
 
     @NotBlank(message = "댓글 내용은 필수입니다.")
+    @Size(max = 400, message = "댓글 내용은 최대 400자까지 입력 가능합니다.")
     private String content;
 }

--- a/src/main/java/com/roome/roome/be/domain/comment/dto/response/CommentResponse.java
+++ b/src/main/java/com/roome/roome/be/domain/comment/dto/response/CommentResponse.java
@@ -1,0 +1,44 @@
+package com.roome.roome.be.domain.comment.dto.response;
+
+import com.roome.roome.be.domain.comment.entity.Comment;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CommentResponse {
+
+    private Long id;
+    private Long userId;
+    private String nickname;
+    private String profileImage;
+    private String content;
+    private Integer likeCount;
+    private Boolean isLiked;
+    private Boolean isAuthor;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private List<CommentResponse> childComments;
+
+    public static CommentResponse from(Comment comment, Long currentUserId, boolean isLiked) {
+        return CommentResponse.builder()
+                .id(comment.getId())
+                .userId(comment.getUser().getId())
+                .nickname(comment.getUser().getNickname())
+                .profileImage(comment.getUser().getProfileImage())
+                .content(comment.getContent())
+                .likeCount(comment.getLikeCount())
+                .isLiked(isLiked)
+                .isAuthor(comment.getUser().getId().equals(currentUserId))
+                .createdAt(comment.getCreatedAt())
+                .updatedAt(comment.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/roome/roome/be/domain/comment/entity/Comment.java
+++ b/src/main/java/com/roome/roome/be/domain/comment/entity/Comment.java
@@ -54,7 +54,7 @@ public class Comment extends BaseEntity {
     @Column(name = "commentable_id", nullable = false)
     private Long commentableId;
 
-    @Column(nullable = false, columnDefinition = "TEXT")
+    @Column(nullable = false, length = 200)
     private String content;
 
     @Column(name = "like_count", nullable = false)

--- a/src/main/java/com/roome/roome/be/domain/comment/entity/Comment.java
+++ b/src/main/java/com/roome/roome/be/domain/comment/entity/Comment.java
@@ -61,6 +61,10 @@ public class Comment extends BaseEntity {
     @Builder.Default
     private Integer likeCount = 0;
 
+    @OneToMany(mappedBy = "comment", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<CommentLike> likes = new ArrayList<>();
+
     public void updateContent(String content) {
         this.content = content;
     }

--- a/src/main/java/com/roome/roome/be/domain/comment/entity/Comment.java
+++ b/src/main/java/com/roome/roome/be/domain/comment/entity/Comment.java
@@ -1,0 +1,85 @@
+package com.roome.roome.be.domain.comment.entity;
+
+import com.roome.roome.be.common.base.BaseEntity;
+import com.roome.roome.be.domain.comment.enums.CommentableType;
+import com.roome.roome.be.domain.user.entity.User;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Comment extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_comment_id")
+    private Comment parentComment;
+
+    @OneToMany(mappedBy = "parentComment", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<Comment> childComments = new ArrayList<>();
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "commentable_type", nullable = false, length = 20)
+    private CommentableType commentableType;
+
+    @Column(name = "commentable_id", nullable = false)
+    private Long commentableId;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Column(name = "like_count", nullable = false)
+    @Builder.Default
+    private Integer likeCount = 0;
+
+    public void updateContent(String content) {
+        this.content = content;
+    }
+
+    public void incrementLikeCount() {
+        this.likeCount++;
+    }
+
+    public void decrementLikeCount() {
+        if (this.likeCount > 0) {
+            this.likeCount--;
+        }
+    }
+
+    public boolean isParentComment() {
+        return this.parentComment == null;
+    }
+
+    public boolean isChildComment() {
+        return this.parentComment != null;
+    }
+}

--- a/src/main/java/com/roome/roome/be/domain/comment/entity/CommentLike.java
+++ b/src/main/java/com/roome/roome/be/domain/comment/entity/CommentLike.java
@@ -1,0 +1,37 @@
+package com.roome.roome.be.domain.comment.entity;
+
+import com.roome.roome.be.common.base.BaseEntity;
+import com.roome.roome.be.domain.user.entity.User;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class CommentLike extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "comment_id", nullable = false)
+    private Comment comment;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+}

--- a/src/main/java/com/roome/roome/be/domain/comment/enums/CommentableType.java
+++ b/src/main/java/com/roome/roome/be/domain/comment/enums/CommentableType.java
@@ -1,0 +1,6 @@
+package com.roome.roome.be.domain.comment.enums;
+
+public enum CommentableType {
+    PRODUCT,
+    FEED
+}

--- a/src/main/java/com/roome/roome/be/domain/comment/enums/CommentableType.java
+++ b/src/main/java/com/roome/roome/be/domain/comment/enums/CommentableType.java
@@ -2,5 +2,5 @@ package com.roome.roome.be.domain.comment.enums;
 
 public enum CommentableType {
     PRODUCT,
-    FEED
+    REFERENCE
 }

--- a/src/main/java/com/roome/roome/be/domain/comment/repository/CommentLikeRepository.java
+++ b/src/main/java/com/roome/roome/be/domain/comment/repository/CommentLikeRepository.java
@@ -1,0 +1,18 @@
+package com.roome.roome.be.domain.comment.repository;
+
+import com.roome.roome.be.domain.comment.entity.CommentLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+import java.util.Set;
+
+public interface CommentLikeRepository extends JpaRepository<CommentLike, Long> {
+
+    Optional<CommentLike> findByCommentIdAndUserId(Long commentId, Long userId);
+    boolean existsByCommentIdAndUserId(Long commentId, Long userId);
+
+    @Query("SELECT cl.comment.id FROM CommentLike cl WHERE cl.user.id = :userId AND cl.comment.id IN :commentIds")
+    Set<Long> findLikedCommentIdsByUserAndCommentIds(@Param("userId") Long userId, @Param("commentIds") Set<Long> commentIds);
+}

--- a/src/main/java/com/roome/roome/be/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/roome/roome/be/domain/comment/repository/CommentRepository.java
@@ -16,7 +16,6 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     @Query("SELECT c FROM Comment c JOIN FETCH c.user WHERE c.parentComment.id = :parentId ORDER BY c.createdAt ASC")
     List<Comment> findChildCommentsByParentId(@Param("parentId") Long parentId);
 
-    // 여러 부모 댓글 ID에 속하는 모든 자식 댓글을 한 번에 조회. (N+1 문제 방지)
     @Query("SELECT c FROM Comment c JOIN FETCH c.user JOIN FETCH c.parentComment WHERE c.parentComment.id IN :parentIds ORDER BY c.createdAt ASC")
     List<Comment> findChildCommentsByParentIds(@Param("parentIds") List<Long> parentIds);
 }

--- a/src/main/java/com/roome/roome/be/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/roome/roome/be/domain/comment/repository/CommentRepository.java
@@ -1,0 +1,22 @@
+package com.roome.roome.be.domain.comment.repository;
+
+import com.roome.roome.be.domain.comment.entity.Comment;
+import com.roome.roome.be.domain.comment.enums.CommentableType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    @Query("SELECT c FROM Comment c JOIN FETCH c.user WHERE c.commentableType = :type AND c.commentableId = :id AND c.parentComment IS NULL ORDER BY c.createdAt DESC")
+    List<Comment> findParentCommentsByCommentable(@Param("type") CommentableType type, @Param("id") Long id);
+
+    @Query("SELECT c FROM Comment c JOIN FETCH c.user WHERE c.parentComment.id = :parentId ORDER BY c.createdAt ASC")
+    List<Comment> findChildCommentsByParentId(@Param("parentId") Long parentId);
+
+    // 여러 부모 댓글 ID에 속하는 모든 자식 댓글을 한 번에 조회. (N+1 문제 방지)
+    @Query("SELECT c FROM Comment c JOIN FETCH c.user JOIN FETCH c.parentComment WHERE c.parentComment.id IN :parentIds ORDER BY c.createdAt ASC")
+    List<Comment> findChildCommentsByParentIds(@Param("parentIds") List<Long> parentIds);
+}

--- a/src/main/java/com/roome/roome/be/domain/comment/service/CommentCoreService.java
+++ b/src/main/java/com/roome/roome/be/domain/comment/service/CommentCoreService.java
@@ -1,0 +1,72 @@
+package com.roome.roome.be.domain.comment.service;
+
+import com.roome.roome.be.domain.comment.converter.CommentConverter;
+import com.roome.roome.be.domain.comment.dto.request.CommentRequest;
+import com.roome.roome.be.domain.comment.dto.request.CommentUpdateRequest;
+import com.roome.roome.be.domain.comment.dto.response.CommentResponse;
+import com.roome.roome.be.domain.comment.entity.Comment;
+import com.roome.roome.be.domain.comment.repository.CommentRepository;
+import com.roome.roome.be.domain.comment.repository.CommentLikeRepository;
+import com.roome.roome.be.domain.user.entity.User;
+import com.roome.roome.be.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CommentCoreService {
+
+    private final CommentRepository commentRepository;
+    private final UserRepository userRepository;
+    private final CommentConverter commentConverter;
+    private final CommentLikeRepository commentLikeRepository;
+
+    private Comment findCommentById(Long commentId) {
+        return commentRepository.findById(commentId)
+                .orElseThrow(() -> new IllegalArgumentException("댓글을 찾을 수 없습니다."));
+    }
+
+    private void validateCommentAuthor(Comment comment, Long userId) {
+        if (!comment.getUser().getId().equals(userId)) {
+            throw new IllegalArgumentException("댓글 수정/삭제 권한이 없습니다.");
+        }
+    }
+
+    // 댓글 생성
+    public CommentResponse createComment(Long userId, CommentRequest requestDto) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        Comment parentComment = null;
+        if (requestDto.getParentCommentId() != null) {
+            parentComment = findCommentById(requestDto.getParentCommentId());
+        }
+
+        Comment comment = commentConverter.toEntity(requestDto, user, parentComment);
+        Comment savedComment = commentRepository.save(comment);
+
+        return commentConverter.toDto(savedComment, userId, false);
+    }
+
+    // 댓글 수정
+    public CommentResponse updateComment(Long userId, Long commentId, CommentUpdateRequest updateDto) {
+        Comment comment = findCommentById(commentId);
+        validateCommentAuthor(comment, userId);
+
+        comment.updateContent(updateDto.getContent());
+
+        boolean isLiked = commentLikeRepository.existsByCommentIdAndUserId(commentId, userId);
+
+        return commentConverter.toDto(comment, userId, isLiked);
+    }
+
+    // 댓글 삭제
+    public void deleteComment(Long userId, Long commentId) {
+        Comment comment = findCommentById(commentId);
+        validateCommentAuthor(comment, userId);
+
+        commentRepository.delete(comment);
+    }
+}

--- a/src/main/java/com/roome/roome/be/domain/comment/service/CommentCoreService.java
+++ b/src/main/java/com/roome/roome/be/domain/comment/service/CommentCoreService.java
@@ -1,5 +1,7 @@
 package com.roome.roome.be.domain.comment.service;
 
+import com.roome.roome.be.common.exception.GeneralException;
+import com.roome.roome.be.common.status.ErrorStatus;
 import com.roome.roome.be.domain.comment.converter.CommentConverter;
 import com.roome.roome.be.domain.comment.dto.request.CommentRequest;
 import com.roome.roome.be.domain.comment.dto.request.CommentUpdateRequest;
@@ -7,6 +9,7 @@ import com.roome.roome.be.domain.comment.dto.response.CommentResponse;
 import com.roome.roome.be.domain.comment.entity.Comment;
 import com.roome.roome.be.domain.comment.repository.CommentRepository;
 import com.roome.roome.be.domain.comment.repository.CommentLikeRepository;
+import com.roome.roome.be.domain.comment.validator.CommentValidator;
 import com.roome.roome.be.domain.user.entity.User;
 import com.roome.roome.be.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -22,26 +25,18 @@ public class CommentCoreService {
     private final UserRepository userRepository;
     private final CommentConverter commentConverter;
     private final CommentLikeRepository commentLikeRepository;
-
-    private Comment findCommentById(Long commentId) {
-        return commentRepository.findById(commentId)
-                .orElseThrow(() -> new IllegalArgumentException("댓글을 찾을 수 없습니다."));
-    }
-
-    private void validateCommentAuthor(Comment comment, Long userId) {
-        if (!comment.getUser().getId().equals(userId)) {
-            throw new IllegalArgumentException("댓글 수정/삭제 권한이 없습니다.");
-        }
-    }
+    private final CommentValidator commentValidator;
 
     // 댓글 생성
     public CommentResponse createComment(Long userId, CommentRequest requestDto) {
+        commentValidator.validateCommentContent(requestDto.getContent());
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
 
+        commentValidator.validateCommentableEntity(requestDto.getCommentableType(), requestDto.getCommentableId());
         Comment parentComment = null;
         if (requestDto.getParentCommentId() != null) {
-            parentComment = findCommentById(requestDto.getParentCommentId());
+            parentComment = commentValidator.findCommentById(requestDto.getParentCommentId());
         }
 
         Comment comment = commentConverter.toEntity(requestDto, user, parentComment);
@@ -52,20 +47,18 @@ public class CommentCoreService {
 
     // 댓글 수정
     public CommentResponse updateComment(Long userId, Long commentId, CommentUpdateRequest updateDto) {
-        Comment comment = findCommentById(commentId);
-        validateCommentAuthor(comment, userId);
-
+        Comment comment = commentValidator.findCommentById(commentId);
+        commentValidator.validateCommentAuthor(comment, userId);
         comment.updateContent(updateDto.getContent());
 
         boolean isLiked = commentLikeRepository.existsByCommentIdAndUserId(commentId, userId);
-
         return commentConverter.toDto(comment, userId, isLiked);
     }
 
     // 댓글 삭제
     public void deleteComment(Long userId, Long commentId) {
-        Comment comment = findCommentById(commentId);
-        validateCommentAuthor(comment, userId);
+        Comment comment = commentValidator.findCommentById(commentId);
+        commentValidator.validateCommentAuthor(comment, userId);
 
         commentRepository.delete(comment);
     }

--- a/src/main/java/com/roome/roome/be/domain/comment/service/CommentLikeService.java
+++ b/src/main/java/com/roome/roome/be/domain/comment/service/CommentLikeService.java
@@ -1,9 +1,12 @@
 package com.roome.roome.be.domain.comment.service;
 
+import com.roome.roome.be.common.exception.GeneralException;
+import com.roome.roome.be.common.status.ErrorStatus;
 import com.roome.roome.be.domain.comment.entity.Comment;
 import com.roome.roome.be.domain.comment.entity.CommentLike;
 import com.roome.roome.be.domain.comment.repository.CommentLikeRepository;
 import com.roome.roome.be.domain.comment.repository.CommentRepository;
+import com.roome.roome.be.domain.comment.validator.CommentValidator;
 import com.roome.roome.be.domain.user.entity.User;
 import com.roome.roome.be.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -15,16 +18,15 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class CommentLikeService {
 
-    private final CommentRepository commentRepository;
     private final CommentLikeRepository commentLikeRepository;
     private final UserRepository userRepository;
+    private final CommentValidator commentValidator;
 
     public void toggleLike(Long userId, Long commentId) {
-        Comment comment = commentRepository.findById(commentId)
-                .orElseThrow(() -> new IllegalArgumentException("댓글을 찾을 수 없습니다."));
+        Comment comment = commentValidator.findCommentById(commentId);
 
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
 
         // 좋아요 상태 확인 및 토글
         commentLikeRepository.findByCommentIdAndUserId(commentId, userId)

--- a/src/main/java/com/roome/roome/be/domain/comment/service/CommentLikeService.java
+++ b/src/main/java/com/roome/roome/be/domain/comment/service/CommentLikeService.java
@@ -1,0 +1,46 @@
+package com.roome.roome.be.domain.comment.service;
+
+import com.roome.roome.be.domain.comment.entity.Comment;
+import com.roome.roome.be.domain.comment.entity.CommentLike;
+import com.roome.roome.be.domain.comment.repository.CommentLikeRepository;
+import com.roome.roome.be.domain.comment.repository.CommentRepository;
+import com.roome.roome.be.domain.user.entity.User;
+import com.roome.roome.be.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CommentLikeService {
+
+    private final CommentRepository commentRepository;
+    private final CommentLikeRepository commentLikeRepository;
+    private final UserRepository userRepository;
+
+    public void toggleLike(Long userId, Long commentId) {
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new IllegalArgumentException("댓글을 찾을 수 없습니다."));
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        // 좋아요 상태 확인 및 토글
+        commentLikeRepository.findByCommentIdAndUserId(commentId, userId)
+                .ifPresentOrElse(
+                        like -> {
+                            commentLikeRepository.delete(like);
+                            comment.decrementLikeCount();
+                        },
+                        () -> {
+                            CommentLike newLike = CommentLike.builder()
+                                    .comment(comment)
+                                    .user(user)
+                                    .build();
+                            commentLikeRepository.save(newLike);
+                            comment.incrementLikeCount();
+                        }
+                );
+    }
+}

--- a/src/main/java/com/roome/roome/be/domain/comment/service/CommentLikeService.java
+++ b/src/main/java/com/roome/roome/be/domain/comment/service/CommentLikeService.java
@@ -5,7 +5,6 @@ import com.roome.roome.be.common.status.ErrorStatus;
 import com.roome.roome.be.domain.comment.entity.Comment;
 import com.roome.roome.be.domain.comment.entity.CommentLike;
 import com.roome.roome.be.domain.comment.repository.CommentLikeRepository;
-import com.roome.roome.be.domain.comment.repository.CommentRepository;
 import com.roome.roome.be.domain.comment.validator.CommentValidator;
 import com.roome.roome.be.domain.user.entity.User;
 import com.roome.roome.be.domain.user.repository.UserRepository;

--- a/src/main/java/com/roome/roome/be/domain/comment/service/CommentReadService.java
+++ b/src/main/java/com/roome/roome/be/domain/comment/service/CommentReadService.java
@@ -1,0 +1,68 @@
+package com.roome.roome.be.domain.comment.service;
+
+import com.roome.roome.be.domain.comment.converter.CommentConverter;
+import com.roome.roome.be.domain.comment.dto.response.CommentResponse;
+import com.roome.roome.be.domain.comment.entity.Comment;
+import com.roome.roome.be.domain.comment.enums.CommentableType;
+import com.roome.roome.be.domain.comment.repository.CommentLikeRepository;
+import com.roome.roome.be.domain.comment.repository.CommentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true) // 읽기 전용 트랜잭션
+public class CommentReadService {
+
+    private final CommentRepository commentRepository;
+    private final CommentLikeRepository commentLikeRepository;
+    private final CommentConverter commentConverter;
+
+    public List<CommentResponse> getComments(Long userId, CommentableType type, Long commentableId) {
+        List<Comment> parentComments = commentRepository.findParentCommentsByCommentable(type, commentableId);
+        List<Long> parentIds = parentComments.stream()
+                .map(Comment::getId)
+                .collect(Collectors.toList());
+
+        List<Comment> childrenComments = commentRepository.findChildCommentsByParentIds(parentIds);
+
+        Set<Long> allCommentIds = new HashSet<>(parentIds);
+        for (Comment child : childrenComments) {
+            allCommentIds.add(child.getId());
+        }
+
+        Set<Long> likedCommentIds = commentLikeRepository.findLikedCommentIdsByUserAndCommentIds(userId, allCommentIds);
+
+        Map<Long, List<Comment>> childrenByParentId = childrenComments.stream()
+                .collect(Collectors.groupingBy(child -> child.getParentComment().getId()));
+
+        List<CommentResponse> result = new ArrayList<>(parentComments.size());
+
+        getchildComments(userId, parentComments, likedCommentIds, childrenByParentId, result);
+        return result;
+    }
+
+    private void getchildComments(Long userId, List<Comment> parentComments, Set<Long> likedCommentIds, Map<Long, List<Comment>> childrenByParentId, List<CommentResponse> result) {
+        for (Comment parent : parentComments) {
+            Long parentId = parent.getId();
+
+            boolean isLiked = likedCommentIds.contains(parentId);
+
+            List<Comment> children = childrenByParentId.getOrDefault(parentId, new ArrayList<>());
+
+            List<CommentResponse> childResponses = new ArrayList<>(children.size());
+            for (Comment child : children) {
+                boolean childIsLiked = likedCommentIds.contains(child.getId());
+                CommentResponse childDto = commentConverter.toDto(child, userId, childIsLiked);
+                childResponses.add(childDto);
+            }
+
+            CommentResponse parentDto = commentConverter.toDtoWithChildren(parent, userId, isLiked, childResponses);
+            result.add(parentDto);
+        }
+    }
+}

--- a/src/main/java/com/roome/roome/be/domain/comment/service/CommentReadService.java
+++ b/src/main/java/com/roome/roome/be/domain/comment/service/CommentReadService.java
@@ -10,12 +10,17 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.*;
+import java.util.List;
+import java.util.Set;
+import java.util.HashSet;
 import java.util.stream.Collectors;
+import java.util.Map;
+import java.util.ArrayList;
+
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true) // 읽기 전용 트랜잭션
+@Transactional(readOnly = true)
 public class CommentReadService {
 
     private final CommentRepository commentRepository;

--- a/src/main/java/com/roome/roome/be/domain/comment/validator/CommentValidator.java
+++ b/src/main/java/com/roome/roome/be/domain/comment/validator/CommentValidator.java
@@ -18,7 +18,7 @@ public class CommentValidator {
     private final ProductRepository productRepository;
     private final ReferenceRepository referenceRepository;
 
-    private static final int MAX_CONTENT_LENGTH = 200;
+    private static final int MAX_CONTENT_LENGTH = 400;
 
     // 댓글이 달릴 대상이 존재하는지 확인
     public void validateCommentableEntity(CommentableType type, Long commentableId) {

--- a/src/main/java/com/roome/roome/be/domain/comment/validator/CommentValidator.java
+++ b/src/main/java/com/roome/roome/be/domain/comment/validator/CommentValidator.java
@@ -1,0 +1,59 @@
+package com.roome.roome.be.domain.comment.validator;
+
+import com.roome.roome.be.common.exception.GeneralException;
+import com.roome.roome.be.common.status.ErrorStatus;
+import com.roome.roome.be.domain.comment.entity.Comment;
+import com.roome.roome.be.domain.comment.enums.CommentableType;
+import com.roome.roome.be.domain.comment.repository.CommentRepository;
+import com.roome.roome.be.domain.product.repository.ProductRepository;
+import com.roome.roome.be.domain.reference.repository.ReferenceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CommentValidator {
+
+    private final CommentRepository commentRepository;
+    private final ProductRepository productRepository;
+    private final ReferenceRepository referenceRepository;
+
+    private static final int MAX_CONTENT_LENGTH = 200;
+
+    // 댓글이 달릴 대상이 존재하는지 확인
+    public void validateCommentableEntity(CommentableType type, Long commentableId) {
+        boolean exists;
+        if (type == CommentableType.PRODUCT) {
+            exists = productRepository.existsById(commentableId);
+        } else if (type == CommentableType.REFERENCE) {
+            exists = referenceRepository.existsById(commentableId);
+        } else {
+            // 지원하지 않는 타입 처리
+            throw new GeneralException(ErrorStatus.COMMENTABLE_ENTITY_NOT_FOUND);
+        }
+
+        if (!exists) {
+            throw new GeneralException(ErrorStatus.COMMENTABLE_ENTITY_NOT_FOUND);
+        }
+    }
+
+    // 댓글 찾기
+    public Comment findCommentById(Long commentId) {
+        return commentRepository.findById(commentId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.COMMENT_NOT_FOUND));
+    }
+
+    // 사용자 댓글 수정, 삭제 권한 확인
+    public void validateCommentAuthor(Comment comment, Long userId) {
+        if (!comment.getUser().getId().equals(userId)) {
+            throw new GeneralException(ErrorStatus.COMMENT_AUTHOR_MISMATCH);
+        }
+    }
+
+    // 댓글 길이 검증
+    public void validateCommentContent(String content) {
+        if (content.length() > MAX_CONTENT_LENGTH) {
+            throw new GeneralException(ErrorStatus.COMMENT_CONTENT_TOO_LONG);
+        }
+    }
+}


### PR DESCRIPTION
## #️⃣ 관련 이슈
closed #50 

## 💡 작업 배경
댓글, 대댓글, 좋아요 기능 구현

## 🧩 작업 내용
**1. 댓글/대댓글 구조 구현**
- Comment 단일 엔티티로 댓글과 대댓글을 모두 처리하며, parentComment 필드를 통해 관계를 설정합니다.
- parentComment가 존재하면 **대댓글(답글)** 로 처리됩니다.
- 댓글 생성, 조회, 수정, 삭제를 위한 API를 구현하였습니다.

**2. 좋아요 (Like) 기능 구현**
- CommentLikeService를 통해 사용자별 좋아요 상태를 토글(Toggle) 하는 기능을 구현했습니다.
- Comment 엔티티의 likeCount 필드를 트랜잭션 내에서 직접 증감시켜 카운트를 관리합니다.

**3. 유효성 검증**
- 내용 길이 제한: 댓글 내용을 최대 400자로 제한하는 검증 로직을 CommentValidator와 Request에 적용했습니다.
- 대상 검증: 댓글이 달릴 대상 엔티티(상품/레퍼런스)의 실제 존재 여부를 확인합니다.
- 권한 검증: 댓글 수정/삭제 시 작성자 권한이 있는지 확인합니다.

## 📸 스크린샷(선택)
<img width="1451" height="358" alt="image" src="https://github.com/user-attachments/assets/4c6ab08d-578b-4285-996c-dbb451dc1918" />
<img width="2832" height="1400" alt="image" src="https://github.com/user-attachments/assets/ffb5648c-cd96-4840-b367-51968b4e88a8" />

- 댓글 생성

<img width="2826" height="1432" alt="image" src="https://github.com/user-attachments/assets/aaa4c80d-ba97-4a3d-958a-164740794275" />
<img width="2842" height="1514" alt="image" src="https://github.com/user-attachments/assets/bc381cc0-4bc6-4d26-9e0b-2283b697fee6" />

- 대댓글 생성, 조회

<img width="2826" height="1464" alt="image" src="https://github.com/user-attachments/assets/de575261-d3a9-4d26-9ff0-3cedf232ff11" />

- 댓글 수정

<img width="2832" height="840" alt="image" src="https://github.com/user-attachments/assets/d380101d-eb37-4713-80c3-aaa98b0f0e6e" />

- 댓글 좋아요 토글

<img width="2834" height="782" alt="image" src="https://github.com/user-attachments/assets/8306e13a-107c-4925-ae69-91a7e65f49a2" />

- 댓글 삭제


## 📝 기타
