### PR TITLE
[Feat] 인기검색어, 최근 검색어 기능구현

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -95,6 +95,9 @@ jobs:
             SHOP_LOGO=${{ secrets.SHOP_LOGO }}
             STORAGE_CDN_BASE_URL=${{ secrets.CDN_BASE_URL }}
             
+            REDIS_HOST=${{ secrets.REDIS_HOST }}  
+            REDIS_PORT=${{ secrets.REDIS_PORT }}
+            
             EOF
          
             sudo chmod +x deploy.sh

--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,7 @@ dependencies {
 
     //redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'io.lettuce:lettuce-core:6.1.5.RELEASE'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,6 @@ dependencies {
 
     //redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-    implementation 'io.lettuce:lettuce-core:6.1.5.RELEASE'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,9 @@ dependencies {
     annotationProcessor "io.github.openfeign.querydsl:querydsl-apt:7.0:jpa"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+
+    //redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: "3.8"
+
+services:
+  redis:
+    image: redis:7
+    container_name: local-redis
+    ports:
+      - "6379:6379"

--- a/src/main/java/com/roome/roome/be/RoomeBeApplication.java
+++ b/src/main/java/com/roome/roome/be/RoomeBeApplication.java
@@ -2,10 +2,12 @@ package com.roome.roome.be;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableCaching
 public class RoomeBeApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/roome/roome/be/common/status/SuccessStatus.java
+++ b/src/main/java/com/roome/roome/be/common/status/SuccessStatus.java
@@ -83,8 +83,13 @@ public enum SuccessStatus implements BaseStatus {
     REGISTER_REFERENCE_SUCCESS("REFERENCE_201", HttpStatus.CREATED,"레퍼런스 등록 성공"),
     REGISTER_REFERENCE_IMAGE_SUCCESS("REFERENCE_201", HttpStatus.CREATED,"레퍼런스 이미지 등록 성공"),
     CREATE_REFERENCE_SCRAP("REFERENCE_200", HttpStatus.OK, "레퍼런스 스크랩 토글 성공"),
-    GET_REFERENCE_LIST_SUCCESS("REFERENCE_200",HttpStatus.OK,"레퍼런스 리스트 조회 성공");
+    GET_REFERENCE_LIST_SUCCESS("REFERENCE_200",HttpStatus.OK,"레퍼런스 리스트 조회 성공"),
 
+    /**
+     * Search
+     */
+    GET_POPULAR_KEYWORDS_LIST_SUCCESS("SEARCH_200",HttpStatus.OK, "인기 검색어 조회 성공"),
+    RECORD_SEARCH_KEYWORD_SUCCESS( "SEARCH_201", HttpStatus.OK,"검색어 기록 성공");
     private final String code;
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/roome/roome/be/common/status/SuccessStatus.java
+++ b/src/main/java/com/roome/roome/be/common/status/SuccessStatus.java
@@ -89,7 +89,9 @@ public enum SuccessStatus implements BaseStatus {
      * Search
      */
     GET_POPULAR_KEYWORDS_LIST_SUCCESS("SEARCH_200",HttpStatus.OK, "인기 검색어 조회 성공"),
-    RECORD_SEARCH_KEYWORD_SUCCESS( "SEARCH_201", HttpStatus.OK,"검색어 기록 성공");
+    RECORD_SEARCH_KEYWORD_SUCCESS( "SEARCH_201", HttpStatus.OK,"검색어 기록 성공"),
+    GET_RECENT_KEYWORDS_LIST_SUCCESS("SEARCH_200",HttpStatus.OK, "최근 검색어 조회 성공");
+
     private final String code;
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/roome/roome/be/domain/product/controller/ProductController.java
+++ b/src/main/java/com/roome/roome/be/domain/product/controller/ProductController.java
@@ -134,9 +134,7 @@ public class ProductController {
 			@ParameterObject
 			@PageableDefault(size = 20, sort = "id", direction = Sort.Direction.DESC) Pageable pageable
 	) {
-		if (keyWord != null && !keyWord.isBlank() && userId != null) {
-			searchService.recordSearch(keyWord, userId);
-		}
+		searchService.recordSearch(keyWord, userId);
 		var page = productService.getList(shopId, category, colorTags, materialTags, styleTags, featureTags, moodTags, match, keyWord, minPrice, maxPrice, pageable, userId);
 		return ApiResponse.success(SuccessStatus.GET_PRODUCT_LIST, page);
 	}

--- a/src/main/java/com/roome/roome/be/domain/product/controller/ProductController.java
+++ b/src/main/java/com/roome/roome/be/domain/product/controller/ProductController.java
@@ -17,6 +17,7 @@ import com.roome.roome.be.domain.product.dto.response.ProductDetailResponse;
 import com.roome.roome.be.domain.product.dto.response.ProductListItemResponse;
 import com.roome.roome.be.domain.product.enums.Category;
 import com.roome.roome.be.domain.product.service.ProductService;
+import com.roome.roome.be.domain.search.service.SearchService;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -34,6 +35,7 @@ import lombok.RequiredArgsConstructor;
 public class ProductController {
 
 	private final ProductService productService;
+	private final SearchService searchService;
 
 	//상품 상세 조회
 	@GetMapping("/{productId}")
@@ -114,6 +116,7 @@ public class ProductController {
 			@Parameter(name = "size", description = "페이지 크기", example = "20")
 	})
 	public ResponseEntity<ApiResponse<Page<ProductListItemResponse>>> getProducts(
+
 			@RequestParam(required = false) Long shopId,
 			@RequestParam(required = false) Category category,
 			@RequestParam(required = false, name = "color") List<String> colorTags,
@@ -131,6 +134,9 @@ public class ProductController {
 			@ParameterObject
 			@PageableDefault(size = 20, sort = "id", direction = Sort.Direction.DESC) Pageable pageable
 	) {
+		if (keyWord != null && !keyWord.isBlank() && userId != null) {
+			searchService.recordSearch(keyWord, userId);
+		}
 		var page = productService.getList(shopId, category, colorTags, materialTags, styleTags, featureTags, moodTags, match, keyWord, minPrice, maxPrice, pageable, userId);
 		return ApiResponse.success(SuccessStatus.GET_PRODUCT_LIST, page);
 	}

--- a/src/main/java/com/roome/roome/be/domain/reference/controller/ReferenceController.java
+++ b/src/main/java/com/roome/roome/be/domain/reference/controller/ReferenceController.java
@@ -4,6 +4,8 @@ import com.roome.roome.be.common.response.ApiResponse;
 import com.roome.roome.be.common.status.SuccessStatus;
 import com.roome.roome.be.domain.reference.dto.response.ReferenceListResponse;
 import com.roome.roome.be.domain.reference.service.ReferenceService;
+import com.roome.roome.be.domain.search.service.SearchService;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -23,6 +25,7 @@ import java.util.List;
 @Tag(name = "Reference")
 public class ReferenceController {
     private final ReferenceService referenceService;
+    private final SearchService searchService;
 
     @GetMapping("")
     @Operation(
@@ -31,8 +34,13 @@ public class ReferenceController {
     )
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "스크랩 내역 리스트 조회 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ReferenceListResponse.class)))
     public ResponseEntity<ApiResponse<ReferenceListResponse>> getReferenceList(
-      @AuthenticationPrincipal Long userId
+        @AuthenticationPrincipal Long userId,
+        @RequestParam(required = false) String keyword
     ){
+        if (keyword != null && !keyword.isBlank() && userId != null) {
+            searchService.recordSearch(keyword, userId);
+        }
+
         ReferenceListResponse response = referenceService.getReferenceList(userId);
         return ApiResponse.success(SuccessStatus.GET_REFERENCE_LIST_SUCCESS,response);
     }

--- a/src/main/java/com/roome/roome/be/domain/reference/controller/ReferenceController.java
+++ b/src/main/java/com/roome/roome/be/domain/reference/controller/ReferenceController.java
@@ -35,10 +35,10 @@ public class ReferenceController {
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "스크랩 내역 리스트 조회 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ReferenceListResponse.class)))
     public ResponseEntity<ApiResponse<ReferenceListResponse>> getReferenceList(
         @AuthenticationPrincipal Long userId,
-        @RequestParam(required = false) String keyword
+        @RequestParam(required = false) String keyWord
     ){
 
-        searchService.recordSearch(keyword, userId);
+        searchService.recordSearch(keyWord, userId);
         ReferenceListResponse response = referenceService.getReferenceList(userId);
         return ApiResponse.success(SuccessStatus.GET_REFERENCE_LIST_SUCCESS,response);
     }

--- a/src/main/java/com/roome/roome/be/domain/reference/controller/ReferenceController.java
+++ b/src/main/java/com/roome/roome/be/domain/reference/controller/ReferenceController.java
@@ -37,10 +37,8 @@ public class ReferenceController {
         @AuthenticationPrincipal Long userId,
         @RequestParam(required = false) String keyword
     ){
-        if (keyword != null && !keyword.isBlank() && userId != null) {
-            searchService.recordSearch(keyword, userId);
-        }
 
+        searchService.recordSearch(keyword, userId);
         ReferenceListResponse response = referenceService.getReferenceList(userId);
         return ApiResponse.success(SuccessStatus.GET_REFERENCE_LIST_SUCCESS,response);
     }

--- a/src/main/java/com/roome/roome/be/domain/reference/service/ReferenceService.java
+++ b/src/main/java/com/roome/roome/be/domain/reference/service/ReferenceService.java
@@ -11,6 +11,7 @@ import com.roome.roome.be.domain.reference.entity.Reference;
 import com.roome.roome.be.domain.reference.entity.ReferenceImage;
 import com.roome.roome.be.domain.reference.repository.ReferenceImageRepository;
 import com.roome.roome.be.domain.reference.repository.ReferenceRepository;
+import com.roome.roome.be.domain.search.service.SearchService;
 import com.roome.roome.be.domain.user.entity.User;
 import com.roome.roome.be.domain.user.repository.UserRepository;
 import com.roome.roome.be.domain.user.repository.UserScrapReferenceRepository;
@@ -32,6 +33,7 @@ public class ReferenceService {
 
     private final S3Service s3Service;
     private final ImageUrlBuilder imageUrlBuilder;
+
 
     // 레퍼런스 등록
     public void registerReference(Long userId, List<MultipartFile> images ) {

--- a/src/main/java/com/roome/roome/be/domain/search/controller/SearchController.java
+++ b/src/main/java/com/roome/roome/be/domain/search/controller/SearchController.java
@@ -1,0 +1,67 @@
+package com.roome.roome.be.domain.search.controller;
+
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.roome.roome.be.common.response.ApiResponse;
+import com.roome.roome.be.common.status.SuccessStatus;
+import com.roome.roome.be.domain.search.dto.request.SearchRequest;
+import com.roome.roome.be.domain.search.dto.response.SearchRankingListResponse;
+import com.roome.roome.be.domain.search.service.SearchService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/search")
+public class SearchController {
+
+	private final SearchService searchService;
+
+	// 검색
+	@PostMapping("/keywords")
+	@Operation(
+		summary = "검색어 기록",
+		description = "검색 발생 시 인기·최근 검색어로 기록합니다."
+	)
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(
+		responseCode = "200",
+		description = "검색어 기록 성공",
+		content = @Content(mediaType = "application/json", schema = @Schema())
+	)
+	public ResponseEntity<ApiResponse<Void>> recordKeyword(
+		@AuthenticationPrincipal Long userId,
+		@RequestBody SearchRequest request
+	) {
+		searchService.recordSearch(request.keyword(), userId);
+		return ApiResponse.success(SuccessStatus.RECORD_SEARCH_KEYWORD_SUCCESS);
+	}
+
+
+	// 인기 검색어
+	@GetMapping(value = "/keywords/popular", produces = MediaType.APPLICATION_JSON_VALUE)
+	@Operation(
+		summary = "인기 검색어 조회",
+		description = "전역 인기 검색어 Top10 목록을 조회합니다."
+	)
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(
+		responseCode = "200",
+		description = "인기 검색어 조회 성공",
+		content = @Content(mediaType = "application/json",
+			schema = @Schema(implementation = SearchRankingListResponse.class))
+	)
+	public ResponseEntity<ApiResponse<SearchRankingListResponse>> getPopularKeywords() {
+		SearchRankingListResponse response = searchService.getPopularKeywords();
+		return ApiResponse.success(SuccessStatus.GET_POPULAR_KEYWORDS_LIST_SUCCESS, response);
+	}
+
+}

--- a/src/main/java/com/roome/roome/be/domain/search/controller/SearchController.java
+++ b/src/main/java/com/roome/roome/be/domain/search/controller/SearchController.java
@@ -1,5 +1,6 @@
 package com.roome.roome.be.domain.search.controller;
 
+
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.roome.roome.be.common.response.ApiResponse;
 import com.roome.roome.be.common.status.SuccessStatus;
 import com.roome.roome.be.domain.search.dto.request.SearchRequest;
+import com.roome.roome.be.domain.search.dto.response.RecentSearchListResponse;
 import com.roome.roome.be.domain.search.dto.response.SearchRankingListResponse;
 import com.roome.roome.be.domain.search.service.SearchService;
 
@@ -27,7 +29,7 @@ public class SearchController {
 
 	private final SearchService searchService;
 
-	// 검색
+	// 1) 검색이 발생할 때 프론트에서 호출
 	@PostMapping("/keywords")
 	@Operation(
 		summary = "검색어 기록",
@@ -47,7 +49,7 @@ public class SearchController {
 	}
 
 
-	// 인기 검색어
+	// 2) 인기 검색어 리스트 조회 (검색 화면 진입 시)
 	@GetMapping(value = "/keywords/popular", produces = MediaType.APPLICATION_JSON_VALUE)
 	@Operation(
 		summary = "인기 검색어 조회",
@@ -62,6 +64,24 @@ public class SearchController {
 	public ResponseEntity<ApiResponse<SearchRankingListResponse>> getPopularKeywords() {
 		SearchRankingListResponse response = searchService.getPopularKeywords();
 		return ApiResponse.success(SuccessStatus.GET_POPULAR_KEYWORDS_LIST_SUCCESS, response);
+	}
+
+	@GetMapping("/keywords/recent")
+	@Operation(
+		summary = "최근 검색어 조회",
+		description = "로그인한 유저의 최근 검색어 10개를 조회합니다. 첫번째 키워드가 가장 최신 검색어 입니다."
+	)
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(
+		responseCode = "200",
+		description = "최근 검색어 조회 성공",
+		content = @Content(mediaType = "application/json",
+			schema = @Schema(implementation = RecentSearchListResponse.class))
+	)
+	public ResponseEntity<ApiResponse<RecentSearchListResponse>> getRecentKeywords(
+		@AuthenticationPrincipal Long userId
+	) {
+		RecentSearchListResponse response = searchService.getRecentSearchList(userId);
+		return ApiResponse.success(SuccessStatus.GET_RECENT_KEYWORDS_LIST_SUCCESS, response);
 	}
 
 }

--- a/src/main/java/com/roome/roome/be/domain/search/controller/SearchController.java
+++ b/src/main/java/com/roome/roome/be/domain/search/controller/SearchController.java
@@ -20,36 +20,19 @@ import com.roome.roome.be.domain.search.service.SearchService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/search")
+@Tag(name = "Search")
 public class SearchController {
 
 	private final SearchService searchService;
 
-	// 1) 검색이 발생할 때 프론트에서 호출
-	@PostMapping("/keywords")
-	@Operation(
-		summary = "검색어 기록",
-		description = "검색 발생 시 인기·최근 검색어로 기록합니다."
-	)
-	@io.swagger.v3.oas.annotations.responses.ApiResponse(
-		responseCode = "200",
-		description = "검색어 기록 성공",
-		content = @Content(mediaType = "application/json", schema = @Schema())
-	)
-	public ResponseEntity<ApiResponse<Void>> recordKeyword(
-		@AuthenticationPrincipal Long userId,
-		@RequestBody SearchRequest request
-	) {
-		searchService.recordSearch(request.keyword(), userId);
-		return ApiResponse.success(SuccessStatus.RECORD_SEARCH_KEYWORD_SUCCESS);
-	}
 
-
-	// 2) 인기 검색어 리스트 조회 (검색 화면 진입 시)
+	// 인기 검색어 리스트 조회 (검색 화면 진입 시)
 	@GetMapping(value = "/keywords/popular", produces = MediaType.APPLICATION_JSON_VALUE)
 	@Operation(
 		summary = "인기 검색어 조회",
@@ -66,6 +49,7 @@ public class SearchController {
 		return ApiResponse.success(SuccessStatus.GET_POPULAR_KEYWORDS_LIST_SUCCESS, response);
 	}
 
+	//최근 검색어
 	@GetMapping("/keywords/recent")
 	@Operation(
 		summary = "최근 검색어 조회",

--- a/src/main/java/com/roome/roome/be/domain/search/dto/request/SearchRequest.java
+++ b/src/main/java/com/roome/roome/be/domain/search/dto/request/SearchRequest.java
@@ -1,0 +1,6 @@
+package com.roome.roome.be.domain.search.dto.request;
+
+public record SearchRequest(
+	String keyword
+) { }
+

--- a/src/main/java/com/roome/roome/be/domain/search/dto/response/RecentSearchListResponse.java
+++ b/src/main/java/com/roome/roome/be/domain/search/dto/response/RecentSearchListResponse.java
@@ -1,0 +1,11 @@
+package com.roome.roome.be.domain.search.dto.response;
+
+import java.util.List;
+
+public record RecentSearchListResponse(
+	List<String> keywords
+) {
+	public static RecentSearchListResponse from(List<String> list) {
+		return new RecentSearchListResponse(list);
+	}
+}

--- a/src/main/java/com/roome/roome/be/domain/search/dto/response/SearchRankingListResponse.java
+++ b/src/main/java/com/roome/roome/be/domain/search/dto/response/SearchRankingListResponse.java
@@ -1,0 +1,9 @@
+package com.roome.roome.be.domain.search.dto.response;
+
+public record SearchRankingListResponse(
+	java.util.List<SearchRankingResponseElement> rankings
+) {
+	public static SearchRankingListResponse from(java.util.List<SearchRankingResponseElement> list) {
+		return new SearchRankingListResponse(list);
+	}
+}

--- a/src/main/java/com/roome/roome/be/domain/search/dto/response/SearchRankingResponseElement.java
+++ b/src/main/java/com/roome/roome/be/domain/search/dto/response/SearchRankingResponseElement.java
@@ -1,0 +1,11 @@
+package com.roome.roome.be.domain.search.dto.response;
+
+public record SearchRankingResponseElement(
+	int rank,
+	String keyword,
+	double score
+) {
+	public static SearchRankingResponseElement of(int rank, String keyword, Double score) {
+		return new SearchRankingResponseElement(rank, keyword, score == null ? 0.0 : score);
+	}
+}

--- a/src/main/java/com/roome/roome/be/domain/search/service/SearchService.java
+++ b/src/main/java/com/roome/roome/be/domain/search/service/SearchService.java
@@ -1,6 +1,7 @@
 package com.roome.roome.be.domain.search.service;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -9,6 +10,7 @@ import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.roome.roome.be.domain.search.dto.response.RecentSearchListResponse;
 import com.roome.roome.be.domain.search.dto.response.SearchRankingListResponse;
 import com.roome.roome.be.domain.search.dto.response.SearchRankingResponseElement;
 
@@ -22,6 +24,8 @@ public class SearchService {
 	private final StringRedisTemplate redisTemplate;
 
 	private static final String POPULAR_KEYWORDS_ZSET_KEY = "search:popularRank:global";
+	private static final String RECENT_KEY_PREFIX = "search::recent::";
+	private static final int RECENT_LIMIT = 10;
 	private static final double RANKING_INCREMENT_SCORE = 1;
 	private static final long RANKING_START = 0L;
 	private static final long RANKING_END = 9L;
@@ -36,6 +40,7 @@ public class SearchService {
 		redisTemplate.opsForZSet()
 			.incrementScore(POPULAR_KEYWORDS_ZSET_KEY, keyword, RANKING_INCREMENT_SCORE);
 
+		addRecentKeyword(userId, keyword);
 	}
 
 	// 인기 검색어
@@ -62,6 +67,37 @@ public class SearchService {
 			.toList();
 
 		return SearchRankingListResponse.from(elements);
+	}
+
+
+	//최근 검색어
+	@Transactional(readOnly = true)
+	public RecentSearchListResponse getRecentSearchList(Long userId) {
+
+		String key = recentKey(userId);
+
+		List<String> list = redisTemplate.opsForList().range(key, 0, RECENT_LIMIT);
+
+		if (list == null) {
+			return RecentSearchListResponse.from(Collections.emptyList());
+		}
+
+		Collections.reverse(list);
+
+		return RecentSearchListResponse.from(list);
+	}
+
+	private void addRecentKeyword(Long userId, String keyword) {
+
+		String key = recentKey(userId);
+
+		redisTemplate.opsForList().remove(key, 0, keyword);
+		redisTemplate.opsForList().rightPush(key, keyword);
+		redisTemplate.opsForList().trim(key, -RECENT_LIMIT, -1);
+	}
+
+	private String recentKey(Long userId) {
+		return RECENT_KEY_PREFIX + userId;
 	}
 
 	private String normalize(String keyword) {

--- a/src/main/java/com/roome/roome/be/domain/search/service/SearchService.java
+++ b/src/main/java/com/roome/roome/be/domain/search/service/SearchService.java
@@ -1,0 +1,70 @@
+package com.roome.roome.be.domain.search.service;
+
+import java.util.Collections;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.roome.roome.be.domain.search.dto.response.SearchRankingListResponse;
+import com.roome.roome.be.domain.search.dto.response.SearchRankingResponseElement;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class SearchService {
+
+	private final StringRedisTemplate redisTemplate;
+
+	private static final String POPULAR_KEYWORDS_ZSET_KEY = "search:popularRank:global";
+	private static final double RANKING_INCREMENT_SCORE = 1;
+	private static final long RANKING_START = 0L;
+	private static final long RANKING_END = 9L;
+
+	//키워드 검색
+	public void recordSearch(String rawKeyword, Long userId) {
+
+		if (rawKeyword == null || rawKeyword.isBlank()) return;
+
+		String keyword = normalize(rawKeyword);
+
+		redisTemplate.opsForZSet()
+			.incrementScore(POPULAR_KEYWORDS_ZSET_KEY, keyword, RANKING_INCREMENT_SCORE);
+
+	}
+
+	// 인기 검색어
+	@Transactional(readOnly = true)
+	public SearchRankingListResponse getPopularKeywords() {
+
+		AtomicInteger rank = new AtomicInteger(1);
+		ZSetOperations<String, String> zSetOps = redisTemplate.opsForZSet();
+
+		var tuples = Optional.ofNullable(
+			zSetOps.reverseRangeWithScores(
+				POPULAR_KEYWORDS_ZSET_KEY,
+				RANKING_START,
+				RANKING_END
+			)
+		).orElse(Collections.emptySet());
+
+		var elements = tuples.stream()
+			.map(t -> SearchRankingResponseElement.of(
+				rank.getAndIncrement(),
+				t.getValue(),
+				t.getScore() == null ? 0.0 : t.getScore()
+			))
+			.toList();
+
+		return SearchRankingListResponse.from(elements);
+	}
+
+	private String normalize(String keyword) {
+		return keyword.trim().replaceAll("\\s+", " ");
+	}
+}

--- a/src/main/java/com/roome/roome/be/domain/shop/controller/ShopController.java
+++ b/src/main/java/com/roome/roome/be/domain/shop/controller/ShopController.java
@@ -57,9 +57,7 @@ public class ShopController {
 		@Parameter(description = "가게 이름 검색어(선택사항), 포함된 검색어가 있으면 반환", example = "이케아")
 		@RequestParam(required = false) String name
 	) {
-		if (name != null && !name.isBlank() && userId != null) {
-			searchService.recordSearch(name, userId);
-		}
+		searchService.recordSearch(name, userId);
 		ShopListResponse shopListResponse = shopService.getShopList(page, size, name);
 		return ApiResponse.success(SuccessStatus.GET_SHOP_LIST_SUCCESS, shopListResponse);
 	}

--- a/src/main/java/com/roome/roome/be/domain/shop/controller/ShopController.java
+++ b/src/main/java/com/roome/roome/be/domain/shop/controller/ShopController.java
@@ -1,6 +1,7 @@
 package com.roome.roome.be.domain.shop.controller;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -9,6 +10,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.roome.roome.be.common.response.ApiResponse;
 import com.roome.roome.be.common.status.SuccessStatus;
+import com.roome.roome.be.domain.search.service.SearchService;
 import com.roome.roome.be.domain.shop.dto.response.ShopDetailResponse;
 import com.roome.roome.be.domain.shop.dto.response.ShopListResponse;
 import com.roome.roome.be.domain.shop.service.ShopService;
@@ -26,6 +28,7 @@ import lombok.RequiredArgsConstructor;
 public class ShopController {
 
 	private final ShopService shopService;
+	private final SearchService searchService;
 
     //가게 상세 조회
 	@GetMapping("/{shopId}")
@@ -46,6 +49,7 @@ public class ShopController {
 	@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "가게 상세 조회 성공", content = @Content)
 	@Operation(summary = "가게 목록 조회: 페이지 최근 가게부터 보여줌(역순)")
 	public ResponseEntity<ApiResponse<ShopListResponse>> getShops(
+		@AuthenticationPrincipal Long userId,
 		@Parameter(description = "조회할 페이지 번호 (0부터 시작)", example = "0")
 		@RequestParam(defaultValue = "0") int page,
 		@Parameter(description = "페이지당 항목 개수", example = "10")
@@ -53,6 +57,9 @@ public class ShopController {
 		@Parameter(description = "가게 이름 검색어(선택사항), 포함된 검색어가 있으면 반환", example = "이케아")
 		@RequestParam(required = false) String name
 	) {
+		if (name != null && !name.isBlank() && userId != null) {
+			searchService.recordSearch(name, userId);
+		}
 		ShopListResponse shopListResponse = shopService.getShopList(page, size, name);
 		return ApiResponse.success(SuccessStatus.GET_SHOP_LIST_SUCCESS, shopListResponse);
 	}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,8 +29,8 @@ spring:
             enable: true
   data:
     redis:
-      host: localhost
-      port: 6379
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
 
   servlet:
     multipart:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,6 +31,7 @@ spring:
     redis:
       host: localhost
       port: 6379
+
   servlet:
     multipart:
       max-file-size: 10MB

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -27,6 +27,10 @@ spring:
           auth: true
           starttls:
             enable: true
+  data:
+    redis:
+      host: localhost
+      port: 6379
   servlet:
     multipart:
       max-file-size: 10MB


### PR DESCRIPTION
## #️⃣ 관련 이슈
closed #42

## 💡 작업 배경
검색 기능을 구체화하기 위해 위해 인기 검색어(전역) / 최근 검색어(유저별) 기능을 추가할 필요가 있어 추가하였습니다.

## 🧩 작업 내용

1.  인기 검색어 구현
- Redis ZSet(search:popularRank:global)을 사용해 검색 빈도를 스코어로 관리
- 검색 발생 시 score +1
- 인기 검색어 TOP10만 반환하도록 구현
- 응답에 랭킹 인덱스 포함

2. 최근 검색어 구현
- Redis List(search::recent::{userId})에 유저별 최근 검색어 최대 10개 저장
- 중복 시 최신 위치로 이동

이때 최근검색어랑 인기검색어는 레퍼런스, 샵, 상품 각각 구현안하고 전역으로 하는게 사용자 입장에서 더 좋다는 내용을 봐서 전역으로 개발하였습니다!
## 📸 스크린샷(선택)
- 인기 검색어
<img width="1121" height="752" alt="Screenshot 2025-11-27 at 12 03 15 AM" src="https://github.com/user-attachments/assets/38733244-6e1f-40ed-b6fd-e0a9cccb6f52" />

- 최근 검색어
<img width="1142" height="804" alt="Screenshot 2025-11-27 at 12 03 02 AM" src="https://github.com/user-attachments/assets/efdc2235-edfc-4939-a2e4-9b9f3218272d" />


## 📝 기타
검색어를 따로 db에 저장하는 것보다 캐시로 관리하는게 일반적이라고 해서 캐시로 구현하였습니다!
혹시 ec2가 다운되는 모르는 상황을 대비해서 따로 캐시를 관리하는게 좋을 것 같아 elasticache를 사용했습니다..! 
운영 환경에서 캐시 서버의 안정성을 위서 aws elasticache 를 사용했고 이 중 Redis 대신 AWS ElastiCache for Valkey( Valkey는 Redis와 완전 호환된다고 해요!)를 사용하도록 구성했습니다. 로컬 환경은 redis로 테스트했고 환경변수 업데이트 해놓았습니다!
