### PR TITLE
[Feat] 상품 조회시 인기순, 최신순, 가격순 정렬

### DIFF
--- a/src/main/java/com/roome/roome/be/domain/product/controller/ProductController.java
+++ b/src/main/java/com/roome/roome/be/domain/product/controller/ProductController.java
@@ -62,11 +62,11 @@ public class ProductController {
 - shopId: 특정 가게의 상품만 조회
 - keyWord: **상품명(name)** 에서만 부분 일치 검색
 - minPrice, maxPrice: 가격 범위 필터
-- **tags: color, material, style, feature, mood (다중 지정 가능)**
+- **tags: color, material, style, feature, mood, usage (다중 지정 가능)**
 - **match: 태그 매칭 방식 (any | all). 기본값 any**
 
 [정렬 가능 필드]
-- id, price, createdAt, popularity (있다면)
+- id, price, createdAt, popularity
 
 [예시]
 - **(신규)** /api/products?category=DININGROOM_CHAIR&color=WHITE&material=WOOD&match=all
@@ -107,6 +107,11 @@ public class ProductController {
 					array = @ArraySchema(schema = @Schema(type = "string"))
 			),
 			@Parameter(
+				name = "usage",
+				description = "사용되는 공간 및 용도(다중 지정 가능) 예: usage=BATHROOM",
+				array = @ArraySchema(schema = @Schema(type = "string"))
+			),
+			@Parameter(
 					name = "match",
 					description = "태그 매칭 방식(any: 하나라도 일치, all: 전부 일치)",
 					schema = @Schema(allowableValues = {"any", "all"}, defaultValue = "any")
@@ -124,6 +129,7 @@ public class ProductController {
 			@RequestParam(required = false, name = "style") List<String> styleTags,
 			@RequestParam(required = false, name = "feature") List<String> featureTags,
 			@RequestParam(required = false, name = "mood") List<String> moodTags,
+			@RequestParam(required = false, name = "usage") List<String> usageTags,
 			@RequestParam(required = false, defaultValue = "any") String match,
 			@RequestParam(required = false) String keyWord,
 			@RequestParam(required = false) Integer minPrice,
@@ -135,7 +141,7 @@ public class ProductController {
 			@PageableDefault(size = 20, sort = "id", direction = Sort.Direction.DESC) Pageable pageable
 	) {
 		searchService.recordSearch(keyWord, userId);
-		var page = productService.getList(shopId, category, colorTags, materialTags, styleTags, featureTags, moodTags, match, keyWord, minPrice, maxPrice, pageable, userId);
+		var page = productService.getList(shopId, category, colorTags, materialTags, styleTags, featureTags, moodTags,usageTags, match, keyWord, minPrice, maxPrice, pageable, userId);
 		return ApiResponse.success(SuccessStatus.GET_PRODUCT_LIST, page);
 	}
 }

--- a/src/main/java/com/roome/roome/be/domain/product/repository/ProductCustomRepositoryImpl.java
+++ b/src/main/java/com/roome/roome/be/domain/product/repository/ProductCustomRepositoryImpl.java
@@ -197,7 +197,7 @@ public class ProductCustomRepositoryImpl implements ProductCustomRepository {
     }
     private void applySort(JPAQuery<Product> query, Pageable pageable) {
 
-        // 기본 정렬 (pageable에 sort 없으면)
+        // 기본 정렬
         if (pageable.getSort().isUnsorted()) {
             query.orderBy(product.id.desc());
             return;
@@ -206,7 +206,7 @@ public class ProductCustomRepositoryImpl implements ProductCustomRepository {
         boolean hasIdSort = false;
 
         for (Sort.Order o : pageable.getSort()) {
-            String prop = o.getProperty();          // "price", "id", "createdAt" ...
+            String prop = o.getProperty();
             Order dir = o.isAscending() ? Order.ASC : Order.DESC;
 
             OrderSpecifier<?> spec = switch (prop) {
@@ -216,6 +216,7 @@ public class ProductCustomRepositoryImpl implements ProductCustomRepository {
                 }
                 case "price" -> new OrderSpecifier<>(dir, product.price);
                 case "createdAt" -> new OrderSpecifier<>(dir, product.createdAt);
+                case "popularity" -> new OrderSpecifier<>(dir, product.likeCount); //좋아요 순
                 default -> null;
             };
 

--- a/src/main/java/com/roome/roome/be/domain/product/repository/ProductCustomRepositoryImpl.java
+++ b/src/main/java/com/roome/roome/be/domain/product/repository/ProductCustomRepositoryImpl.java
@@ -1,5 +1,7 @@
 package com.roome.roome.be.domain.product.repository;
 
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.CaseBuilder;
@@ -14,6 +16,7 @@ import com.roome.roome.be.domain.product.enums.TagType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.support.PageableExecutionUtils;
 
 import java.util.List;
@@ -59,9 +62,10 @@ public class ProductCustomRepositoryImpl implements ProductCustomRepository {
         );
 
         // 3. 페이징 및 정렬 적용
-        query
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize());
+        applySort(query, pageable);
+
+        query.offset(pageable.getOffset())
+            .limit(pageable.getPageSize());
 
         // 4. 쿼리 실행 (Content)
         List<Product> content = query.fetch();
@@ -190,6 +194,37 @@ public class ProductCustomRepositoryImpl implements ProductCustomRepository {
                         new CaseBuilder()
                                 .when(productTag.tag.id.in(tagIds)).then(1).otherwise(0)
                 );
+    }
+    private void applySort(JPAQuery<Product> query, Pageable pageable) {
+
+        // 기본 정렬 (pageable에 sort 없으면)
+        if (pageable.getSort().isUnsorted()) {
+            query.orderBy(product.id.desc());
+            return;
+        }
+
+        boolean hasIdSort = false;
+
+        for (Sort.Order o : pageable.getSort()) {
+            String prop = o.getProperty();          // "price", "id", "createdAt" ...
+            Order dir = o.isAscending() ? Order.ASC : Order.DESC;
+
+            OrderSpecifier<?> spec = switch (prop) {
+                case "id" -> {
+                    hasIdSort = true;
+                    yield new OrderSpecifier<>(dir, product.id);
+                }
+                case "price" -> new OrderSpecifier<>(dir, product.price);
+                case "createdAt" -> new OrderSpecifier<>(dir, product.createdAt);
+                default -> null;
+            };
+
+            if (spec != null) query.orderBy(spec);
+        }
+
+        if (!hasIdSort) {
+            query.orderBy(product.id.desc());
+        }
     }
 
 }

--- a/src/main/java/com/roome/roome/be/domain/product/service/ProductService.java
+++ b/src/main/java/com/roome/roome/be/domain/product/service/ProductService.java
@@ -130,6 +130,7 @@ public class ProductService {
             List<String> styleTags,
             List<String> featureTags,
             List<String> moodTags,
+            List<String> usageTags,
             String match,                // 기본 any
             String keyWord,
             Integer minPrice,
@@ -147,6 +148,8 @@ public class ProductService {
         if (styleTags != null && !styleTags.isEmpty()) tagFilters.put(TagType.STYLE, styleTags);
         if (featureTags != null && !featureTags.isEmpty()) tagFilters.put(TagType.FEATURE, featureTags);
         if (moodTags != null && !moodTags.isEmpty()) tagFilters.put(TagType.MOOD, moodTags);
+        if (usageTags != null && !usageTags.isEmpty()) tagFilters.put(TagType.USAGE, usageTags);
+
 
         Page<Product> page = productRepository.findByDynamicFilters(
                 shopId,


### PR DESCRIPTION
## #️⃣ 관련 이슈
closed #58 

## 💡 작업 배경
상품 조회시 정렬 기능이 필요하여 추가하였다.

## 🧩 작업 내용

- 기존 기능에서는 처음 조회시에만 적용이 되고 추후에 조회시에는 적용이 안되고 있어 최신순, 가격순 정렬 기능 구현을 수정
- 인기순 구현은 좋아요 순으로 구현
- 피그마에 방타입별로 필터가 있어 tag 테이블 내 type 중 usage을 사용하여 사용 공간 및 용도도 필터링이 가능하도록 구현

## 📸 스크린샷(선택)
<img width="864" height="818" alt="Screenshot 2025-12-28 at 12 58 22 AM" src="https://github.com/user-attachments/assets/e1e8cc6a-5cd0-4dcf-9d0c-5b513ddef5f2" />

## 📝 기타
