### PR TITLE
[Feat] 레퍼런스 좋아요 기능 구현

### DIFF
--- a/src/main/java/com/roome/roome/be/common/status/SuccessStatus.java
+++ b/src/main/java/com/roome/roome/be/common/status/SuccessStatus.java
@@ -45,6 +45,7 @@ public enum SuccessStatus implements BaseStatus {
     SAVE_USER_ONBOARDING_SUCCESS("AUTH_201", HttpStatus.CREATED, "유저 온보딩 저장 성공"),
     CHECK_USER_ONBOARDING_EXISTENCE_SUCCESS("AUTH_200", HttpStatus.OK, "유저 온보딩 존재 여부 조회 성공"),
     GET_USER_LIKE_PRODUCT_LIST_SUCCESS("USER_200",HttpStatus.OK, "유저 좋아요 상품 리스트 조회 성공"),
+    GET_USER_LIKE_REFERENCE_LIST_SUCCESS("PRODUCT_200",HttpStatus.OK,"유저 좋아요 레퍼런스 리스트 조회 성공" ),
     GET_USER_SCRAP_PRODUCT_LIST_SUCCESS("USER_200",HttpStatus.OK, "유저 스크랩 상품 리스트 조회 성공"),
     GET_USER_SCRAP_REFERENCE_LIST_SUCCESS("USER_200",HttpStatus.OK, "유저 스크랩 레퍼런스 리스트 조회 성공"),
     GET_USER_PROFILE_SUCCESS("USER_200",HttpStatus.OK,"유저 프로필 조회 성공"),
@@ -84,6 +85,7 @@ public enum SuccessStatus implements BaseStatus {
     REGISTER_REFERENCE_IMAGE_SUCCESS("REFERENCE_201", HttpStatus.CREATED,"레퍼런스 이미지 등록 성공"),
     CREATE_REFERENCE_SCRAP("REFERENCE_200", HttpStatus.OK, "레퍼런스 스크랩 토글 성공"),
     GET_REFERENCE_LIST_SUCCESS("REFERENCE_200",HttpStatus.OK,"레퍼런스 리스트 조회 성공"),
+    CREATE_REFERENCE_LIKE("REFERENCE_200",HttpStatus.OK,"레퍼런스 좋아요 토글 성공" ),
 
     /**
      * Comment

--- a/src/main/java/com/roome/roome/be/domain/product/service/ProductService.java
+++ b/src/main/java/com/roome/roome/be/domain/product/service/ProductService.java
@@ -4,7 +4,7 @@ import java.util.*;
 
 import com.roome.roome.be.domain.product.dto.response.*;
 import com.roome.roome.be.domain.product.enums.TagType;
-import com.roome.roome.be.domain.user.repository.UserLikeRepository;
+import com.roome.roome.be.domain.user.repository.UserLikeProductRepository;
 import com.roome.roome.be.domain.user.service.UserViewService;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
@@ -40,7 +40,7 @@ public class ProductService {
     private final ShopRepository shopRepository;
     private final ProductImageRepository productImageRepository;
     private final ProductTagRepository productTagRepository;
-    private final UserLikeRepository userLikeRepository;
+    private final UserLikeProductRepository userLikeProductRepository;
 
     private final ProductTagService productTagService;
     private final ProductImageService productImageService;
@@ -169,7 +169,7 @@ public class ProductService {
                     .toList();
 
             if (!productIds.isEmpty()) {
-                likedProductIds = userLikeRepository.findLikedProductIds(userId, productIds);
+                likedProductIds = userLikeProductRepository.findLikedProductIds(userId, productIds);
             }
         }
 

--- a/src/main/java/com/roome/roome/be/domain/reference/dto/response/ReferenceToggleLikeResponse.java
+++ b/src/main/java/com/roome/roome/be/domain/reference/dto/response/ReferenceToggleLikeResponse.java
@@ -1,0 +1,6 @@
+package com.roome.roome.be.domain.reference.dto.response;
+
+public record ReferenceToggleLikeResponse(
+        boolean liked
+) {
+}

--- a/src/main/java/com/roome/roome/be/domain/reference/entity/Reference.java
+++ b/src/main/java/com/roome/roome/be/domain/reference/entity/Reference.java
@@ -36,6 +36,5 @@ public class Reference extends BaseEntity {
         if (this.likeCount > 0) {
             this.likeCount--;
         }
-
     }
 }

--- a/src/main/java/com/roome/roome/be/domain/reference/entity/Reference.java
+++ b/src/main/java/com/roome/roome/be/domain/reference/entity/Reference.java
@@ -27,4 +27,15 @@ public class Reference extends BaseEntity {
 
     @OneToMany(mappedBy = "reference", fetch = FetchType.LAZY)
     private List<ReferenceImage> referenceImageList = new ArrayList<>();
+
+    @Column(name = "like_count",nullable = false)
+    private Integer likeCount;
+
+    public void incrementLikeCount() { this.likeCount++; }
+    public void decrementLikeCount() {
+        if (this.likeCount > 0) {
+            this.likeCount--;
+        }
+
+    }
 }

--- a/src/main/java/com/roome/roome/be/domain/reference/entity/ReferenceImage.java
+++ b/src/main/java/com/roome/roome/be/domain/reference/entity/ReferenceImage.java
@@ -21,4 +21,10 @@ public class ReferenceImage extends BaseEntity {
     @Column(nullable = false, length = 256, unique = true)
     private String objectKey;
 
+    @Column(nullable = false)
+    private int sortOrder;
+
+    @Column(nullable = false, length = 512, unique = true)
+    private String imageUrl;
+
 }

--- a/src/main/java/com/roome/roome/be/domain/reference/service/ReferenceService.java
+++ b/src/main/java/com/roome/roome/be/domain/reference/service/ReferenceService.java
@@ -1,5 +1,11 @@
 package com.roome.roome.be.domain.reference.service;
 
+import java.util.Comparator;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
 import com.roome.roome.be.common.exception.GeneralException;
 import com.roome.roome.be.common.s3.enums.StorageScope;
 import com.roome.roome.be.common.s3.service.ImageUrlBuilder;
@@ -11,16 +17,11 @@ import com.roome.roome.be.domain.reference.entity.Reference;
 import com.roome.roome.be.domain.reference.entity.ReferenceImage;
 import com.roome.roome.be.domain.reference.repository.ReferenceImageRepository;
 import com.roome.roome.be.domain.reference.repository.ReferenceRepository;
-import com.roome.roome.be.domain.search.service.SearchService;
 import com.roome.roome.be.domain.user.entity.User;
 import com.roome.roome.be.domain.user.repository.UserRepository;
 import com.roome.roome.be.domain.user.repository.UserScrapReferenceRepository;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.web.multipart.MultipartFile;
 
-import java.util.Comparator;
-import java.util.List;
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
@@ -94,4 +95,5 @@ public class ReferenceService {
         return referenceRepository.findById(referenceId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.REFERENCE_NOT_FOUND));
     }
+
 }

--- a/src/main/java/com/roome/roome/be/domain/user/controller/UserController.java
+++ b/src/main/java/com/roome/roome/be/domain/user/controller/UserController.java
@@ -1,5 +1,20 @@
 package com.roome.roome.be.domain.user.controller;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
 import com.roome.roome.be.common.response.ApiResponse;
 import com.roome.roome.be.common.response.PageResponse;
 import com.roome.roome.be.common.status.SuccessStatus;
@@ -8,12 +23,25 @@ import com.roome.roome.be.domain.inquiry.enums.InquiryType;
 import com.roome.roome.be.domain.inquiry.service.InquiryService;
 import com.roome.roome.be.domain.product.dto.response.ProductToggleLikeResponse;
 import com.roome.roome.be.domain.product.dto.response.ProductToggleScrapResponse;
+import com.roome.roome.be.domain.reference.dto.response.ReferenceToggleLikeResponse;
 import com.roome.roome.be.domain.reference.dto.response.ReferenceToggleScrapResponse;
 import com.roome.roome.be.domain.user.dto.request.UpdateUserProfileRequest;
 import com.roome.roome.be.domain.user.dto.request.UserInquirySearchCondition;
 import com.roome.roome.be.domain.user.dto.request.UserOnboardingRequest;
-import com.roome.roome.be.domain.user.dto.response.*;
-import com.roome.roome.be.domain.user.service.*;
+import com.roome.roome.be.domain.user.dto.response.UserInquiryResponse;
+import com.roome.roome.be.domain.user.dto.response.UserLikeProductListResponse;
+import com.roome.roome.be.domain.user.dto.response.UserLikeReferenceListResponse;
+import com.roome.roome.be.domain.user.dto.response.UserOnboardingExistResponse;
+import com.roome.roome.be.domain.user.dto.response.UserProfileResponse;
+import com.roome.roome.be.domain.user.dto.response.UserRecentViewedProductListResponse;
+import com.roome.roome.be.domain.user.dto.response.UserScrappedProductListResponse;
+import com.roome.roome.be.domain.user.dto.response.UserScrappedReferenceListResponse;
+import com.roome.roome.be.domain.user.service.UserLikeService;
+import com.roome.roome.be.domain.user.service.UserOnboardingService;
+import com.roome.roome.be.domain.user.service.UserScrapService;
+import com.roome.roome.be.domain.user.service.UserService;
+import com.roome.roome.be.domain.user.service.UserViewService;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
@@ -22,12 +50,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -90,7 +112,7 @@ public class UserController {
     }
 
     // 상품 좋아요 기능 구현
-    @PostMapping("/likes/{productId}")
+    @PostMapping("/likes/product/{productId}")
     @Operation(
             summary = "상품 좋아요 토글",
             description = "이미 좋아요가 눌려 있으면 취소하고, 눌려 있지 않으면 좋아요를 추가합니다."
@@ -108,7 +130,7 @@ public class UserController {
         return ApiResponse.success(SuccessStatus.CREATE_PRODUCT_LIKE,response);
     }
 
-    @GetMapping("/likes")
+    @GetMapping("/likes/product")
     @Operation(summary = "유저가 좋아요를 누른 상품 리스트 조회")
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "좋아요 상품 리스트 조회 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = UserLikeProductListResponse.class)))
     public ResponseEntity<ApiResponse<UserLikeProductListResponse>> getUserLikedProductList(
@@ -118,8 +140,37 @@ public class UserController {
         return ApiResponse.success(SuccessStatus.GET_USER_LIKE_PRODUCT_LIST_SUCCESS, response);
     }
 
+    // 레퍼런스 좋아요 기능 구현
+    @PostMapping("/likes/reference/{referenceId}")
+    @Operation(
+        summary = "레퍼런스 좋아요 토글",
+        description = "이미 좋아요가 눌려 있으면 취소하고, 눌려 있지 않으면 좋아요를 추가합니다."
+    )
+    @Parameters({
+        @Parameter(name = "referenceId", description = "좋아요를 누를 레퍼런스의 ID", example = "123"),
+    })
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "좋아요 토글 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ReferenceToggleLikeResponse.class)))
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "유저가 존재하지 않거나 레퍼런스가 존재하지 않음", content = @Content(mediaType = "application/json"))
+    public ResponseEntity<ApiResponse<ReferenceToggleLikeResponse>> toggleReferenceLike(
+        @PathVariable("referenceId") Long referenceId,
+        @AuthenticationPrincipal Long userId
+    ) {
+        ReferenceToggleLikeResponse response = userLikeService.toggleReferenceLike(referenceId, userId);
+        return ApiResponse.success(SuccessStatus.CREATE_REFERENCE_LIKE,response);
+    }
+
+    @GetMapping("/likes/reference")
+    @Operation(summary = "유저가 좋아요를 누른 레퍼런스 리스트 조회")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "좋아요 레퍼런스 리스트 조회 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = UserLikeReferenceListResponse.class)))
+    public ResponseEntity<ApiResponse<UserLikeReferenceListResponse>> getUserLikedReferenceList(
+        @AuthenticationPrincipal Long userId
+    ) {
+        UserLikeReferenceListResponse response = userLikeService.getUserLikedReferenceList(userId);
+        return ApiResponse.success(SuccessStatus.GET_USER_LIKE_REFERENCE_LIST_SUCCESS, response);
+    }
+
     // 상품 스크랩 기능 구현
-    @PostMapping("/scraps/{productId}")
+    @PostMapping("/scraps/product/{productId}")
     @Operation(
             summary = "상품 스크랩 토글",
             description = "이미 스크랩이 되어 있으면 취소하고, 되어 있지 않으면 스크랩에 추가합니다."
@@ -137,7 +188,7 @@ public class UserController {
         return ApiResponse.success(SuccessStatus.CREATE_PRODUCT_LIKE,response);
     }
 
-    @PostMapping("/scraps/{referenceId}")
+    @PostMapping("/scraps/reference/{referenceId}")
     @Operation(
             summary = "레퍼런스 스크랩 토글 ",
             description = "이미 스크랩이 되어 있으면 취소하고, 되어 있지 않으면 스크랩에 추가합니다."

--- a/src/main/java/com/roome/roome/be/domain/user/dto/response/UserLikeReferenceListResponse.java
+++ b/src/main/java/com/roome/roome/be/domain/user/dto/response/UserLikeReferenceListResponse.java
@@ -1,0 +1,10 @@
+package com.roome.roome.be.domain.user.dto.response;
+
+import java.util.List;
+
+import com.roome.roome.be.domain.reference.dto.response.CommonReferenceInfo;
+
+public record UserLikeReferenceListResponse(
+	List<CommonReferenceInfo> userLikeReferenceList
+) {
+}

--- a/src/main/java/com/roome/roome/be/domain/user/entity/UserLikeProduct.java
+++ b/src/main/java/com/roome/roome/be/domain/user/entity/UserLikeProduct.java
@@ -21,7 +21,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-public class UserLike extends BaseEntity {
+public class UserLikeProduct extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/roome/roome/be/domain/user/entity/UserLikeReference.java
+++ b/src/main/java/com/roome/roome/be/domain/user/entity/UserLikeReference.java
@@ -1,0 +1,37 @@
+package com.roome.roome.be.domain.user.entity;
+
+import com.roome.roome.be.common.base.BaseEntity;
+import com.roome.roome.be.domain.reference.entity.Reference;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class UserLikeReference extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY, optional = false)
+	@JoinColumn(name = "user_id", nullable = false)
+	private User user;
+
+	@ManyToOne(fetch = FetchType.LAZY, optional = false)
+	@JoinColumn(name = "reference_id", nullable = false)
+	private Reference reference;
+}

--- a/src/main/java/com/roome/roome/be/domain/user/repository/UserLikeProductCustomRepository.java
+++ b/src/main/java/com/roome/roome/be/domain/user/repository/UserLikeProductCustomRepository.java
@@ -4,6 +4,6 @@ import com.roome.roome.be.domain.product.dto.response.CommonProductInfo;
 
 import java.util.List;
 
-public interface UserLikeCustomRepository {
+public interface UserLikeProductCustomRepository {
     List<CommonProductInfo> findUserLikeProductListByUserId(Long userId);
 }

--- a/src/main/java/com/roome/roome/be/domain/user/repository/UserLikeProductCustomRepositoryImpl.java
+++ b/src/main/java/com/roome/roome/be/domain/user/repository/UserLikeProductCustomRepositoryImpl.java
@@ -15,24 +15,24 @@ import static com.roome.roome.be.domain.product.entity.QProduct.product;
 import static com.roome.roome.be.domain.product.entity.QProductImage.productImage;
 import static com.roome.roome.be.domain.product.entity.QProductTag.productTag;
 import static com.roome.roome.be.domain.product.entity.QTag.tag;
-import static com.roome.roome.be.domain.user.entity.QUserLike.userLike;
+import static com.roome.roome.be.domain.user.entity.QUserLikeProduct.*;
 
 @Repository
 @RequiredArgsConstructor
-public class UserLikeCustomRepositoryImpl implements UserLikeCustomRepository {
+public class UserLikeProductCustomRepositoryImpl implements UserLikeProductCustomRepository {
 
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
     public List<CommonProductInfo> findUserLikeProductListByUserId(Long userId) {
         return jpaQueryFactory
-                .from(userLike)
-                .join(userLike.product, product)
+                .from(userLikeProduct)
+                .join(userLikeProduct.product, product)
                 .leftJoin(product.productImageList, productImage)
                 .leftJoin(product.productTagList, productTag)
                 .leftJoin(productTag.tag, tag)
-                .where(userLike.user.id.eq(userId))
-                .orderBy(userLike.updatedAt.desc())
+                .where(userLikeProduct.user.id.eq(userId))
+                .orderBy(userLikeProduct.updatedAt.desc())
                 .transform(
                         groupBy(product.id).list(
                                 Projections.constructor(CommonProductInfo.class,

--- a/src/main/java/com/roome/roome/be/domain/user/repository/UserLikeProductRepository.java
+++ b/src/main/java/com/roome/roome/be/domain/user/repository/UserLikeProductRepository.java
@@ -2,7 +2,8 @@ package com.roome.roome.be.domain.user.repository;
 
 import com.roome.roome.be.domain.product.entity.Product;
 import com.roome.roome.be.domain.user.entity.User;
-import com.roome.roome.be.domain.user.entity.UserLike;
+import com.roome.roome.be.domain.user.entity.UserLikeProduct;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -11,9 +12,9 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
-public interface UserLikeRepository extends JpaRepository<UserLike, Long> {
-    public Optional<UserLike> findByUserAndProduct(User user, Product product);
+public interface UserLikeProductRepository extends JpaRepository<UserLikeProduct, Long> {
+    public Optional<UserLikeProduct> findByUserAndProduct(User user, Product product);
 
-    @Query("SELECT ul.product.id FROM UserLike ul WHERE ul.user.id = :userId AND ul.product.id IN :productIds")
+    @Query("SELECT ul.product.id FROM UserLikeProduct ul WHERE ul.user.id = :userId AND ul.product.id IN :productIds")
     Set<Long> findLikedProductIds(@Param("userId") Long userId, @Param("productIds") List<Long> productIds);
 }

--- a/src/main/java/com/roome/roome/be/domain/user/repository/UserLikeProductRepository.java
+++ b/src/main/java/com/roome/roome/be/domain/user/repository/UserLikeProductRepository.java
@@ -15,6 +15,6 @@ import java.util.Set;
 public interface UserLikeProductRepository extends JpaRepository<UserLikeProduct, Long> {
     public Optional<UserLikeProduct> findByUserAndProduct(User user, Product product);
 
-    @Query("SELECT ul.product.id FROM UserLikeProduct ul WHERE ul.user.id = :userId AND ul.product.id IN :productIds")
+    @Query("SELECT ulp.product.id FROM UserLikeProduct ulp WHERE ulp.user.id = :userId AND ulp.product.id IN :productIds")
     Set<Long> findLikedProductIds(@Param("userId") Long userId, @Param("productIds") List<Long> productIds);
 }

--- a/src/main/java/com/roome/roome/be/domain/user/repository/UserLikeReferenceCustomRepository.java
+++ b/src/main/java/com/roome/roome/be/domain/user/repository/UserLikeReferenceCustomRepository.java
@@ -1,0 +1,9 @@
+package com.roome.roome.be.domain.user.repository;
+
+import java.util.List;
+
+import com.roome.roome.be.domain.reference.dto.response.CommonReferenceInfo;
+
+public interface UserLikeReferenceCustomRepository {
+    List<CommonReferenceInfo> findUserLikeReferenceListByUserId(Long userId);
+}

--- a/src/main/java/com/roome/roome/be/domain/user/repository/UserLikeReferenceCustomRepositoryImpl.java
+++ b/src/main/java/com/roome/roome/be/domain/user/repository/UserLikeReferenceCustomRepositoryImpl.java
@@ -1,0 +1,49 @@
+package com.roome.roome.be.domain.user.repository;
+
+import static com.querydsl.core.group.GroupBy.*;
+import static com.roome.roome.be.domain.reference.entity.QReference.*;
+import static com.roome.roome.be.domain.reference.entity.QReferenceImage.*;
+import static com.roome.roome.be.domain.user.entity.QUser.*;
+import static com.roome.roome.be.domain.user.entity.QUserLikeReference.*;
+
+
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.roome.roome.be.domain.reference.dto.response.CommonReferenceInfo;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class UserLikeReferenceCustomRepositoryImpl implements UserLikeReferenceCustomRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<CommonReferenceInfo> findUserLikeReferenceListByUserId(Long userId) {
+        return jpaQueryFactory
+            .from(userLikeReference)
+            .join(userLikeReference.user, user)
+            .join(userLikeReference.reference, reference)
+            .leftJoin(reference.referenceImageList, referenceImage)
+            .where(userLikeReference.user.id.eq(userId))
+            .orderBy(userLikeReference.updatedAt.desc())
+            .transform(
+                groupBy(reference.id).list(
+                    Projections.constructor(
+                        CommonReferenceInfo.class,
+                        reference.id,
+                        user.nickname,
+                        user.id,
+                        list(referenceImage.imageUrl),
+                        reference.scrapCount
+                    )
+                )
+            );
+    }
+}

--- a/src/main/java/com/roome/roome/be/domain/user/repository/UserLikeReferenceRepository.java
+++ b/src/main/java/com/roome/roome/be/domain/user/repository/UserLikeReferenceRepository.java
@@ -1,0 +1,20 @@
+package com.roome.roome.be.domain.user.repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.roome.roome.be.domain.reference.entity.Reference;
+import com.roome.roome.be.domain.user.entity.User;
+import com.roome.roome.be.domain.user.entity.UserLikeReference;
+
+public interface UserLikeReferenceRepository extends JpaRepository<UserLikeReference, Long> {
+    public Optional<UserLikeReference> findByUserAndReference(User user, Reference reference);
+
+    @Query("SELECT ulr.reference.id FROM UserLikeReference ulr WHERE ulr.user.id = :userId AND ulr.reference.id IN :referenceIds")
+    Set<Long> findLikedReferenceIds(@Param("userId") Long userId, @Param("referenceIds") List<Long> referenceIds);
+}

--- a/src/main/java/com/roome/roome/be/domain/user/service/UserLikeService.java
+++ b/src/main/java/com/roome/roome/be/domain/user/service/UserLikeService.java
@@ -6,9 +6,9 @@ import com.roome.roome.be.domain.product.entity.Product;
 import com.roome.roome.be.domain.product.service.ProductService;
 import com.roome.roome.be.domain.user.dto.response.UserLikeProductListResponse;
 import com.roome.roome.be.domain.user.entity.User;
-import com.roome.roome.be.domain.user.entity.UserLike;
-import com.roome.roome.be.domain.user.repository.UserLikeCustomRepository;
-import com.roome.roome.be.domain.user.repository.UserLikeRepository;
+import com.roome.roome.be.domain.user.entity.UserLikeProduct;
+import com.roome.roome.be.domain.user.repository.UserLikeProductCustomRepository;
+import com.roome.roome.be.domain.user.repository.UserLikeProductRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,8 +20,8 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class UserLikeService {
 
-    private final UserLikeRepository userLikeRepository;
-    private final UserLikeCustomRepository userLikeCustomRepository;
+    private final UserLikeProductRepository userLikeRepository;
+    private final UserLikeProductCustomRepository userLikeCustomRepository;
 
     private final UserService userService;
     private final ProductService productService;
@@ -34,13 +34,13 @@ public class UserLikeService {
 
         boolean liked;
 
-        Optional<UserLike> existing = userLikeRepository.findByUserAndProduct(user, product);
+        Optional<UserLikeProduct> existing = userLikeRepository.findByUserAndProduct(user, product);
         if (existing.isEmpty()) {
-            UserLike userLike = UserLike.builder()
+            UserLikeProduct userLikeProduct = UserLikeProduct.builder()
                     .user(user)
                     .product(product)
                     .build();
-            userLikeRepository.save(userLike);
+            userLikeRepository.save(userLikeProduct);
             liked = true;
             product.incrementLikeCount();
         }

--- a/src/main/java/com/roome/roome/be/domain/user/service/UserLikeService.java
+++ b/src/main/java/com/roome/roome/be/domain/user/service/UserLikeService.java
@@ -1,30 +1,43 @@
 package com.roome.roome.be.domain.user.service;
 
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.roome.roome.be.domain.product.dto.response.CommonProductInfo;
 import com.roome.roome.be.domain.product.dto.response.ProductToggleLikeResponse;
 import com.roome.roome.be.domain.product.entity.Product;
 import com.roome.roome.be.domain.product.service.ProductService;
+import com.roome.roome.be.domain.reference.dto.response.CommonReferenceInfo;
+import com.roome.roome.be.domain.reference.dto.response.ReferenceToggleLikeResponse;
+import com.roome.roome.be.domain.reference.entity.Reference;
+import com.roome.roome.be.domain.reference.service.ReferenceService;
 import com.roome.roome.be.domain.user.dto.response.UserLikeProductListResponse;
+import com.roome.roome.be.domain.user.dto.response.UserLikeReferenceListResponse;
 import com.roome.roome.be.domain.user.entity.User;
 import com.roome.roome.be.domain.user.entity.UserLikeProduct;
+import com.roome.roome.be.domain.user.entity.UserLikeReference;
 import com.roome.roome.be.domain.user.repository.UserLikeProductCustomRepository;
 import com.roome.roome.be.domain.user.repository.UserLikeProductRepository;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
+import com.roome.roome.be.domain.user.repository.UserLikeReferenceCustomRepository;
+import com.roome.roome.be.domain.user.repository.UserLikeReferenceRepository;
 
-import java.util.List;
-import java.util.Optional;
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 public class UserLikeService {
 
-    private final UserLikeProductRepository userLikeRepository;
-    private final UserLikeProductCustomRepository userLikeCustomRepository;
+    private final UserLikeProductRepository userLikeProductRepository;
+    private final UserLikeProductCustomRepository userLikeProductCustomRepository;
+    private final UserLikeReferenceRepository userLikeReferenceRepository;
+    private final UserLikeReferenceCustomRepository userLikeReferenceCustomRepository;
 
     private final UserService userService;
     private final ProductService productService;
+    private final ReferenceService referenceService;
 
     // 상품 좋아요 or 좋아요 취소 기능 구현
     @Transactional
@@ -34,18 +47,18 @@ public class UserLikeService {
 
         boolean liked;
 
-        Optional<UserLikeProduct> existing = userLikeRepository.findByUserAndProduct(user, product);
+        Optional<UserLikeProduct> existing = userLikeProductRepository.findByUserAndProduct(user, product);
         if (existing.isEmpty()) {
             UserLikeProduct userLikeProduct = UserLikeProduct.builder()
                     .user(user)
                     .product(product)
                     .build();
-            userLikeRepository.save(userLikeProduct);
+            userLikeProductRepository.save(userLikeProduct);
             liked = true;
             product.incrementLikeCount();
         }
         else {
-            userLikeRepository.delete(existing.get());
+            userLikeProductRepository.delete(existing.get());
             liked = false;
             product.decrementLikeCount();
         }
@@ -55,8 +68,41 @@ public class UserLikeService {
 
     // 유저가 좋아요를 누른 상품 리스트 조회
     public UserLikeProductListResponse getUserLikedProductList(Long userId) {
-        List<CommonProductInfo> userLikeProductList = userLikeCustomRepository.findUserLikeProductListByUserId(userId);
+        List<CommonProductInfo> userLikeProductList = userLikeProductCustomRepository.findUserLikeProductListByUserId(userId);
         return new UserLikeProductListResponse(userLikeProductList);
+    }
+
+    // 레퍼런스 좋아요 or 좋아요 취소 기능 구현
+    @Transactional
+    public ReferenceToggleLikeResponse toggleReferenceLike(Long referenceId, Long userId) {
+        Reference reference = referenceService.findReferenceById(referenceId);
+        User user = userService.getUserById(userId);
+
+        boolean liked;
+
+        Optional<UserLikeReference> existing = userLikeReferenceRepository.findByUserAndReference(user, reference);
+        if (existing.isEmpty()) {
+            UserLikeReference userLikeReference = UserLikeReference.builder()
+                .user(user)
+                .reference(reference)
+                .build();
+            userLikeReferenceRepository.save(userLikeReference);
+            liked = true;
+            reference.incrementLikeCount();
+        }
+        else {
+            userLikeReferenceRepository.delete(existing.get());
+            liked = false;
+            reference.decrementLikeCount();
+        }
+
+        return new ReferenceToggleLikeResponse(liked);
+    }
+
+    // 유저가 좋아요를 누른 레퍼런스 리스트 조회
+    public UserLikeReferenceListResponse getUserLikedReferenceList(Long userId) {
+        List<CommonReferenceInfo> userLikeReferenceList = userLikeReferenceCustomRepository.findUserLikeReferenceListByUserId(userId);
+        return new UserLikeReferenceListResponse(userLikeReferenceList);
     }
 
 }


### PR DESCRIPTION
## #️⃣ 관련 이슈
closed #60 

## 💡 작업 배경
현재 레퍼런스 좋아요 기능이 누락되었다.


## 🧩 작업 내용
- 기존의 상품 좋아요 테이블인 userLike을 userLikeProduct로 변경
- 레퍼런스 좋아요 테이블 userLikeReference 생성
- 레퍼런스 테이블 내 컬럼 추가 구현
- 레퍼런스 좋아요 토글 기능 구현
- 레퍼런스 좋아요 조회 기능 구현

## 📸 스크린샷(선택)
<img width="943" height="571" alt="Screenshot 2025-12-29 at 1 45 36 AM" src="https://github.com/user-attachments/assets/33c7fb83-18a9-471e-98e5-5c7195659ef4" />
<img width="1052" height="614" alt="Screenshot 2025-12-29 at 1 43 24 AM" src="https://github.com/user-attachments/assets/2f540687-67aa-4ffb-9b64-9cb7d920cd73" />


## 📝 기타
제 로컬 db에서는 userLikeProduct로 수정했는데 아직 rds에서는 userLikeProduct로 수정안해놓았습니다!
미리 바꾸면.. 혹시 프론트쪽에서 api호출시 오류날까봐,,,머지할때 바꿔놓을게요!
