### PR TITLE
[Feat] Redis 설정 및 시나리오 대화 상태값 저장 기능 구현

### DIFF
--- a/src/main/java/com/roome/roome/be/common/config/RedisConfig.java
+++ b/src/main/java/com/roome/roome/be/common/config/RedisConfig.java
@@ -1,0 +1,37 @@
+package com.roome.roome.be.common.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(
+            RedisConnectionFactory factory
+    ) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(factory);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+        GenericJackson2JsonRedisSerializer serializer =
+                new GenericJackson2JsonRedisSerializer(objectMapper);
+
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(serializer);
+        template.setHashKeySerializer(new StringRedisSerializer());
+        template.setHashValueSerializer(serializer);
+
+        return template;
+    }
+}

--- a/src/main/java/com/roome/roome/be/common/redis/RedisRepository.java
+++ b/src/main/java/com/roome/roome/be/common/redis/RedisRepository.java
@@ -1,0 +1,29 @@
+package com.roome.roome.be.common.redis;
+
+import com.roome.roome.be.domain.chat.model.ChatSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+
+@Repository
+@RequiredArgsConstructor
+public class RedisRepository {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private static final String PREFIX = "chat:session:";
+
+    public void save(ChatSession chatSession) {
+        redisTemplate.opsForValue()
+                .set(PREFIX + chatSession.userId(), chatSession, Duration.ofHours(3));
+    }
+
+    public ChatSession find(Long userId) {
+        return (ChatSession) redisTemplate.opsForValue().get(PREFIX + userId);
+    }
+
+    public void delete(Long userId) {
+        redisTemplate.delete(PREFIX + userId);
+    }
+}

--- a/src/main/java/com/roome/roome/be/common/redis/RedisService.java
+++ b/src/main/java/com/roome/roome/be/common/redis/RedisService.java
@@ -1,0 +1,24 @@
+package com.roome.roome.be.common.redis;
+
+import com.roome.roome.be.domain.chat.model.ChatSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RedisService {
+
+    private final RedisRepository redisRepository;
+
+    public void save(ChatSession chatSession){
+        redisRepository.save(chatSession);
+    }
+
+    public ChatSession get(Long userId) {
+        return redisRepository.find(userId);
+    }
+
+    public void clear(Long userId) {
+        redisRepository.delete(userId);
+    }
+}

--- a/src/main/java/com/roome/roome/be/domain/chat/model/ChatSession.java
+++ b/src/main/java/com/roome/roome/be/domain/chat/model/ChatSession.java
@@ -1,0 +1,28 @@
+package com.roome.roome.be.domain.chat.model;
+
+import com.roome.roome.be.domain.chat.enums.ChatMode;
+
+import java.time.LocalDateTime;
+
+public record ChatSession(
+        Long userId,
+        ChatMode chatMode,
+        Object request,
+        Object response,
+        LocalDateTime createdAt
+) {
+    public static ChatSession from(
+            Long userId,
+            ChatMode chatMode,
+            Object request,
+            Object response
+    ) {
+        return new ChatSession(
+                userId,
+                chatMode,
+                request,
+                response,
+                LocalDateTime.now()
+        );
+    }
+}

--- a/src/main/java/com/roome/roome/be/domain/chat/service/ChatService.java
+++ b/src/main/java/com/roome/roome/be/domain/chat/service/ChatService.java
@@ -1,5 +1,6 @@
 package com.roome.roome.be.domain.chat.service;
 
+import com.roome.roome.be.common.redis.RedisService;
 import com.roome.roome.be.domain.ai.dto.request.AiProductRequest;
 import com.roome.roome.be.domain.ai.dto.request.AiReferenceRequest;
 import com.roome.roome.be.domain.ai.dto.response.AiProductResponse;
@@ -10,6 +11,8 @@ import com.roome.roome.be.domain.chat.dto.request.ChatReferenceScenarioRequest;
 import com.roome.roome.be.domain.chat.dto.response.ChatProductScenarioResponse;
 import com.roome.roome.be.domain.chat.dto.response.ProductSummaryResponse;
 import com.roome.roome.be.domain.chat.dto.response.ChatReferenceScenarioResponse;
+import com.roome.roome.be.domain.chat.enums.ChatMode;
+import com.roome.roome.be.domain.chat.model.ChatSession;
 import com.roome.roome.be.domain.product.dto.response.CandidateProductInfo;
 import com.roome.roome.be.domain.product.enums.ProductCategory;
 import com.roome.roome.be.domain.product.enums.ProductTypeMapper;
@@ -36,6 +39,7 @@ public class ChatService {
     private final ReferenceService referenceService;
     private final UserService userService;
     private final AiService aiService;
+    private final RedisService redisService;
 
     public ChatReferenceScenarioResponse processChatReferenceScenario(Long userId, ChatReferenceScenarioRequest request) {
         User user = userService.getUserById(userId);
@@ -77,8 +81,11 @@ public class ChatService {
                         AiReferenceRequest.from(user.getNickname(),request, candidateReferenceList)
                 );
 
+
         // 응답 변환
-        return ChatReferenceScenarioResponse.from(aiResult);
+        ChatReferenceScenarioResponse response = ChatReferenceScenarioResponse.from(aiResult);
+        redisService.save(ChatSession.from(userId, ChatMode.REFERENCE, request, response));
+        return response;
 
     }
 
@@ -127,7 +134,9 @@ public class ChatService {
                         .filter(Objects::nonNull)
                         .toList();
 
-        return ChatProductScenarioResponse.from(result);
+        ChatProductScenarioResponse response = ChatProductScenarioResponse.from(result);
+        redisService.save(ChatSession.from(userId,ChatMode.PRODUCT, request,response));
+        return response;
     }
 }
 


### PR DESCRIPTION
## #️⃣ 관련 이슈
closed #64 

## 💡 작업 배경
- 시나리오 대화 이후 챗봇과의 대화를 이어가려면 Redis에 대화값을 저장해야 함

## 🧩 작업 내용
- Redis Config 설정
- ChatService에서 각각의 로직 수행 후 RedisService 호출하여 상태 저장

## 📸 스크린샷(선택)
<img width="1816" height="588" alt="image" src="https://github.com/user-attachments/assets/b8e05a61-93f1-4779-99d5-acf6f5147c31" />


## 📝 기타
로컬에서는 정상적으로 저장되는 걸 확인하였고 머지 후에 서버에서 테스트 해보겠습니다!