### PR TITLE
[Fix] 레퍼런스 이미지 경로 수정

### DIFF
--- a/src/main/java/com/roome/roome/be/domain/reference/service/ReferenceService.java
+++ b/src/main/java/com/roome/roome/be/domain/reference/service/ReferenceService.java
@@ -124,9 +124,9 @@ public class ReferenceService {
 
         List<String> images = ref.getReferenceImageList().stream()
                 .sorted(Comparator.comparing(ReferenceImage::getSortOrder))
-                .map(ReferenceImage::getObjectKey)              // objectKey 가져와서
+                .map(ReferenceImage::getObjectKey)
                 .filter(Objects::nonNull)
-                .map(imageUrlBuilder::build)                    // 우리 빌더로 URL 생성
+                .map(imageUrlBuilder::build)
                 .toList();
 
         List<ReferenceItemProductInfo> items = ref.getReferenceItemList().stream()

--- a/src/main/java/com/roome/roome/be/domain/reference/service/ReferenceService.java
+++ b/src/main/java/com/roome/roome/be/domain/reference/service/ReferenceService.java
@@ -124,7 +124,9 @@ public class ReferenceService {
 
         List<String> images = ref.getReferenceImageList().stream()
                 .sorted(Comparator.comparing(ReferenceImage::getSortOrder))
-                .map(ReferenceImage::getImageUrl)
+                .map(ReferenceImage::getObjectKey)              // objectKey 가져와서
+                .filter(Objects::nonNull)
+                .map(imageUrlBuilder::build)                    // 우리 빌더로 URL 생성
                 .toList();
 
         List<ReferenceItemProductInfo> items = ref.getReferenceItemList().stream()
@@ -212,8 +214,8 @@ public class ReferenceService {
                 .filter(Objects::nonNull)
                 .map(ref -> {
                     String thumbnail = ref.getReferenceImageList().isEmpty()
-                            ? null
-                            : ref.getReferenceImageList().get(0).getImageUrl();
+                        ? null
+                        : imageUrlBuilder.build(ref.getReferenceImageList().get(0).getObjectKey());
 
                     return new RelatedReferenceResponse(
                             ref.getId(),


### PR DESCRIPTION
## #️⃣ 관련 이슈
closed #78

## 💡 작업 배경
레퍼런스 이미지 경로에서 오류가 나고 있다.

## 🧩 작업 내용

- s3에 레퍼런스 이미지가 없는데 이미지 경로는 s3경로를 내려주고 있어 s3에 레퍼런스 이미지 업로드(각 레퍼런스 id 사용)
- objectKey 경로 레퍼런스 id로 통일

## 📸 스크린샷(선택)
<img width="1021" height="535" alt="Screenshot 2026-01-02 at 2 12 17 PM" src="https://github.com/user-attachments/assets/18b1a8f9-28db-49df-9e1c-60903d975fe9" />


## 📝 기타
s3에 업로드 후 테스트 했을때는 이미지 잘 접속됩니다! 
references/ 폴더에 넣어두었습니다!
