### PR TITLE
[Feat] 최근 검색어 삭제 기능 구현

### DIFF
--- a/src/main/java/com/roome/roome/be/common/status/SuccessStatus.java
+++ b/src/main/java/com/roome/roome/be/common/status/SuccessStatus.java
@@ -104,6 +104,7 @@ public enum SuccessStatus implements BaseStatus {
     GET_POPULAR_KEYWORDS_LIST_SUCCESS("SEARCH_200",HttpStatus.OK, "인기 검색어 조회 성공"),
     RECORD_SEARCH_KEYWORD_SUCCESS( "SEARCH_201", HttpStatus.OK,"검색어 기록 성공"),
     GET_RECENT_KEYWORDS_LIST_SUCCESS("SEARCH_200",HttpStatus.OK, "최근 검색어 조회 성공"),
+    DELETE_RECENT_KEYWORD_SUCCESS("SEARCH_200", HttpStatus.OK,"최근 검색어 개별 삭제 성공" ),
 
 
     /**

--- a/src/main/java/com/roome/roome/be/common/status/SuccessStatus.java
+++ b/src/main/java/com/roome/roome/be/common/status/SuccessStatus.java
@@ -105,6 +105,7 @@ public enum SuccessStatus implements BaseStatus {
     RECORD_SEARCH_KEYWORD_SUCCESS( "SEARCH_201", HttpStatus.OK,"검색어 기록 성공"),
     GET_RECENT_KEYWORDS_LIST_SUCCESS("SEARCH_200",HttpStatus.OK, "최근 검색어 조회 성공"),
     DELETE_RECENT_KEYWORD_SUCCESS("SEARCH_200", HttpStatus.OK,"최근 검색어 개별 삭제 성공" ),
+    DELETE_ALL_RECENT_KEYWORDS_SUCCESS("SEARCH_200", HttpStatus.OK,"최근 검색어 전체 삭제 성공" ),
 
 
     /**

--- a/src/main/java/com/roome/roome/be/domain/search/controller/SearchController.java
+++ b/src/main/java/com/roome/roome/be/domain/search/controller/SearchController.java
@@ -4,8 +4,10 @@ package com.roome.roome.be.domain.search.controller;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.roome.roome.be.common.response.ApiResponse;
@@ -63,6 +65,24 @@ public class SearchController {
 	) {
 		RecentSearchListResponse response = searchService.getRecentSearchList(userId);
 		return ApiResponse.success(SuccessStatus.GET_RECENT_KEYWORDS_LIST_SUCCESS, response);
+	}
+
+	// 최근 검색어 개별 삭제
+	@DeleteMapping("/keywords/recent")
+	@Operation(
+		summary = "최근 검색어 삭제",
+		description = "로그인한 유저의 최근 검색어 중 특정 키워드를 삭제합니다."
+	)
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(
+		responseCode = "200",
+		description = "최근 검색어 삭제 성공"
+	)
+	public ResponseEntity<ApiResponse<Void>> deleteRecentKeyword(
+		@AuthenticationPrincipal Long userId,
+		@RequestParam String keyword
+	) {
+		searchService.deleteRecentKeyword(userId, keyword);
+		return ApiResponse.success(SuccessStatus.DELETE_RECENT_KEYWORD_SUCCESS, null);
 	}
 
 }

--- a/src/main/java/com/roome/roome/be/domain/search/controller/SearchController.java
+++ b/src/main/java/com/roome/roome/be/domain/search/controller/SearchController.java
@@ -85,4 +85,21 @@ public class SearchController {
 		return ApiResponse.success(SuccessStatus.DELETE_RECENT_KEYWORD_SUCCESS, null);
 	}
 
+	// 최근 검색어 전체 삭제
+	@DeleteMapping("/keywords/recent/all")
+	@Operation(
+		summary = "최근 검색어 전체 삭제",
+		description = "로그인한 유저의 최근 검색어를 모두 삭제합니다."
+	)
+	@io.swagger.v3.oas.annotations.responses.ApiResponse(
+		responseCode = "200",
+		description = "최근 검색어 전체 삭제 성공"
+	)
+	public ResponseEntity<ApiResponse<Void>> deleteAllRecentKeywords(
+		@AuthenticationPrincipal Long userId
+	) {
+		searchService.deleteAllRecentKeywords(userId);
+		return ApiResponse.success(SuccessStatus.DELETE_ALL_RECENT_KEYWORDS_SUCCESS, null);
+	}
+
 }

--- a/src/main/java/com/roome/roome/be/domain/search/service/SearchService.java
+++ b/src/main/java/com/roome/roome/be/domain/search/service/SearchService.java
@@ -104,6 +104,12 @@ public class SearchService {
 		redisTemplate.opsForList().remove(key, 0, keyword);
 	}
 
+	// 최근 검색어 전체 삭제
+	public void deleteAllRecentKeywords(Long userId) {
+		String key = recentKey(userId);
+		redisTemplate.delete(key);
+	}
+
 	private String recentKey(Long userId) {
 		return RECENT_KEY_PREFIX + userId;
 	}

--- a/src/main/java/com/roome/roome/be/domain/search/service/SearchService.java
+++ b/src/main/java/com/roome/roome/be/domain/search/service/SearchService.java
@@ -98,6 +98,12 @@ public class SearchService {
 		redisTemplate.expire(key, RECENT_TTL);
 	}
 
+	// 최근 검색어 개별 삭제
+	public void deleteRecentKeyword(Long userId, String keyword) {
+		String key = recentKey(userId);
+		redisTemplate.opsForList().remove(key, 0, keyword);
+	}
+
 	private String recentKey(Long userId) {
 		return RECENT_KEY_PREFIX + userId;
 	}

--- a/src/main/java/com/roome/roome/be/domain/search/service/SearchService.java
+++ b/src/main/java/com/roome/roome/be/domain/search/service/SearchService.java
@@ -1,5 +1,6 @@
 package com.roome.roome.be.domain.search.service;
 
+import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -29,6 +30,7 @@ public class SearchService {
 	private static final double RANKING_INCREMENT_SCORE = 1;
 	private static final long RANKING_START = 0L;
 	private static final long RANKING_END = 9L;
+	private static final Duration RECENT_TTL = Duration.ofDays(90);
 
 	//키워드 검색
 	public void recordSearch(String rawKeyword, Long userId) {
@@ -90,10 +92,10 @@ public class SearchService {
 	private void addRecentKeyword(Long userId, String keyword) {
 
 		String key = recentKey(userId);
-
 		redisTemplate.opsForList().remove(key, 0, keyword);
 		redisTemplate.opsForList().rightPush(key, keyword);
 		redisTemplate.opsForList().trim(key, -RECENT_LIMIT, -1);
+		redisTemplate.expire(key, RECENT_TTL);
 	}
 
 	private String recentKey(Long userId) {


### PR DESCRIPTION
## #️⃣ 관련 이슈
closed #82

## 💡 작업 배경
기획, 디자인 변경으로 최근 검색어 삭제 기능이 필요하여 구현하였다.

## 🧩 작업 내용

- ttl 설정을 90일로 하여 최근 검색어가 90일동안 유지되도록 설정
- 최근 검색어 개별 삭제 기능 구현
- 최근 검색어 전체 삭제 기능 구현


## 📸 스크린샷(선택)
- 개별 삭제
1. 현재
<img width="2034" height="1300" alt="image" src="https://github.com/user-attachments/assets/451e571f-8905-43e5-9b1f-c584c95593c4" />
2. 삭제
<img width="2042" height="1568" alt="image" src="https://github.com/user-attachments/assets/acfb20d5-e391-4a62-905d-a0a3a7c9449c" />
3. 결과
<img width="2176" height="1270" alt="image" src="https://github.com/user-attachments/assets/a0690618-31e1-4754-b78e-8da5a2e4c809" />


-전체삭제
1. 삭제
<img width="2150" height="1108" alt="image" src="https://github.com/user-attachments/assets/178ffb2e-81f0-4385-a5e9-a111b61034aa" />

2. 결과
<img width="2184" height="1194" alt="image" src="https://github.com/user-attachments/assets/69a43123-d8c1-4780-826d-69f257dcbd0f" />



## 📝 기타
검색어 전체 삭제 기능은 기획에는 없는데 뭔가 필요할 수도 있을 것 같아 전체 삭제도 구현했습니다..!
그리고 ut에서 진행한 피드백 읽어보았을뗴 "bed" 관련 오류가 있었는데 백엔드 쪽을 몇시간동안 살펴보았는데.... 아무리 오류가 없더라고요...
그래서 프론트 코드 살펴보았는데 여기서 디폴트로 검색시 bed가 포함되는 것 같아서.. 이 부분 오늘 회의때 프론트분들께 여쭈어보겠습니다..!
다들 화이팅...! 2주남았다.... 그리고 저도 테스트 하면서 이상한 부분들? 버그? 있었는데 이 부분들은 내일 회의때 정리해서 말씀드릴게요..!
