### PR TITLE
[fix] 레퍼런스, 상품 조회시 중복 상품id 가지면 한개만 조회하도록 수정

### DIFF
--- a/src/main/java/com/roome/roome/be/domain/product/repository/ProductCustomRepositoryImpl.java
+++ b/src/main/java/com/roome/roome/be/domain/product/repository/ProductCustomRepositoryImpl.java
@@ -111,6 +111,7 @@ public class ProductCustomRepositoryImpl implements ProductCustomRepository {
                 .leftJoin(productTag).on(product.id.eq(productTag.product.id))
                 .leftJoin(tag).on(productTag.tag.id.eq(tag.id).and(tag.type.eq(TagType.PRODUCT_TYPE)))
                 .where(product.id.ne(excludeProductId))
+                .groupBy(product.id)
                 .orderBy(relevanceScore.desc())
                 .limit(20)
                 .fetch();

--- a/src/main/java/com/roome/roome/be/domain/reference/service/ReferenceService.java
+++ b/src/main/java/com/roome/roome/be/domain/reference/service/ReferenceService.java
@@ -130,17 +130,24 @@ public class ReferenceService {
                 .toList();
 
         List<ReferenceItemProductInfo> items = ref.getReferenceItemList().stream()
-                .map(item -> {
-                    Product p = item.getProduct();
+                .map(com.roome.roome.be.domain.reference.entity.ReferenceItem::getProduct)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toMap(
+                        Product::getId,
+                        product -> product,
+                        (existing, replacement) -> existing,
+                        LinkedHashMap::new
+                ))
+                .values().stream()
+                .map(p -> {
 
                     String thumb = null;
 
                     if (p.getThumbnailKey() != null && !p.getThumbnailKey().isBlank()) {
                         thumb = imageUrlBuilder.build(p.getThumbnailKey());
-                    }
-                    else if (!p.getProductImageList().isEmpty()) {
+                    } else if (!p.getProductImageList().isEmpty()) {
                         thumb = p.getProductImageList().stream()
-                                .sorted(Comparator.comparingInt(ProductImage::getSortOrder)) // 순서대로 정렬
+                                .sorted(Comparator.comparingInt(ProductImage::getSortOrder))
                                 .findFirst()
                                 .map(ProductImage::getImageUrl)
                                 .orElse(null);
@@ -192,6 +199,7 @@ public class ReferenceService {
                 ref.getReferenceUrl()
         );
     }
+
 
     // 상품 관련 레퍼런스 조회
     @Transactional


### PR DESCRIPTION
## #️⃣ 관련 이슈
closed #86 

## 💡 작업 배경
레퍼런스, 상품 상세 조회시 관련 product로 중복된 아이디의 상품 여러개가  조회되는 문제

## 🧩 작업 내용
중복 id가 여러개 조회되는 문제는 해결했습니다..!

## 📸 스크린샷(선택)
<img width="1425" height="757" alt="image" src="https://github.com/user-attachments/assets/3e072db0-1052-4cca-a0b7-80155ba5f0cd" />
<img width="1411" height="716" alt="image" src="https://github.com/user-attachments/assets/129a4d00-b21e-4b6e-962f-0eab6b47a5bd" />


## 📝 기타
