### PR TITLE
[Feat] 회원가입 시 닉네임에 길이 제한 추가

### DIFF
--- a/src/main/java/com/roome/roome/be/domain/auth/dto/request/SignUpRequest.java
+++ b/src/main/java/com/roome/roome/be/domain/auth/dto/request/SignUpRequest.java
@@ -11,6 +11,7 @@ public record SignUpRequest(
         String email,
 
         @NotBlank(message = "닉네임은 필수입니다.")
+        @Size(max = 20, message = "닉네임은 20자를 초과할 수 없습니다.")
         String nickname,
 
         @NotBlank(message = "비밀번호는 필수입니다.")


### PR DESCRIPTION
## #️⃣ 관련 이슈
closed #90 

## 💡 작업 배경
- 회원가입 시 닉네임 길이 제한이 빠져 있음

## 🧩 작업 내용
-  SignUpRequest nickname에 validation 추가

## 📸 스크린샷(선택)
<img width="608" height="439" alt="image" src="https://github.com/user-attachments/assets/08516458-d18d-4daa-a84d-20dbb1dc3dfd" />


## 📝 기타
