### PR TITLE
[Feat] 상품, 레퍼런스 관련 조회 시 좋아요, 스크랩 값 추가

### DIFF
--- a/src/main/java/com/roome/roome/be/domain/product/controller/ProductController.java
+++ b/src/main/java/com/roome/roome/be/domain/product/controller/ProductController.java
@@ -49,7 +49,7 @@ public class ProductController {
 			@PathVariable Long productId,
 			@AuthenticationPrincipal Long userId
 	) {
-		var dto = productService.getDetail(productId, userId);
+		var dto = productService.getProductDetail(productId, userId);
 		return ApiResponse.success(SuccessStatus.GET_PRODUCT_DETAIL, dto);
 	}
 

--- a/src/main/java/com/roome/roome/be/domain/product/dto/response/CommonProductInfo.java
+++ b/src/main/java/com/roome/roome/be/domain/product/dto/response/CommonProductInfo.java
@@ -15,6 +15,10 @@ public record CommonProductInfo(
         String thumbnailKey,
         Set<String> imageList,
         Set<Tag> tagList,
+		Integer likeCount,
+		Integer scrapCount,
+		Boolean isLiked,
+		Boolean isScrapped,
         LocalDateTime createdAt,
         LocalDateTime updatedAt
 ) {

--- a/src/main/java/com/roome/roome/be/domain/product/dto/response/ProductDetailResponse.java
+++ b/src/main/java/com/roome/roome/be/domain/product/dto/response/ProductDetailResponse.java
@@ -15,6 +15,10 @@ public record ProductDetailResponse(
 	String description,
 	ShopSummaryResponse shop,
 	String thumbnailUrl,
+	Integer likeCount,
+	Integer scrapCount,
+	Boolean isLiked,
+	Boolean isScrapped,
 	List<ProductImageResponse> images,
 	List<ProductTagResponse> tags,
 	List<RelatedProductResponse> relatedProductList
@@ -26,7 +30,9 @@ public record ProductDetailResponse(
 			List<ProductImageResponse> images,
 			List<ProductTagResponse> tags,
 			ShopSummaryResponse shop,
-			List<RelatedProductResponse> relatedProductList
+			List<RelatedProductResponse> relatedProductList,
+			Boolean isLiked,
+			Boolean isScrapped
 	) {
 		return new ProductDetailResponse(
 				product.getId(),
@@ -37,6 +43,10 @@ public record ProductDetailResponse(
 				product.getDescription(),
 				shop,
 				thumbnailUrl,
+				product.getLikeCount(),
+				product.getScrapCount(),
+				isLiked,
+				isScrapped,
 				images,
 				tags,
 				relatedProductList

--- a/src/main/java/com/roome/roome/be/domain/product/dto/response/ProductListItemResponse.java
+++ b/src/main/java/com/roome/roome/be/domain/product/dto/response/ProductListItemResponse.java
@@ -16,9 +16,12 @@ public record ProductListItemResponse(
 	String thumbnailUrl,
 	Long shopId,
 	String shopName,
-	boolean isLiked
+	Integer scrapCount,
+	Integer likeCount,
+	boolean isLiked,
+	boolean isScrapped
 ) {
-	public static ProductListItemResponse from(Product product, ProductCategory category, ImageUrlBuilder imageUrlBuilder, boolean isLiked) {
+	public static ProductListItemResponse from(Product product, ProductCategory category, ImageUrlBuilder imageUrlBuilder, boolean isLiked, boolean isScrapped) {
 		String productUrl = product.getProductUrl() != null ? product.getProductUrl() : null;
 
 		String thumbnailUrl = product.getThumbnailKey() != null
@@ -37,7 +40,10 @@ public record ProductListItemResponse(
 				thumbnailUrl,
 				shopId,
 				shopName,
-				isLiked
+				product.getScrapCount(),
+				product.getLikeCount(),
+				isLiked,
+				isScrapped
 		);
 	}
 }

--- a/src/main/java/com/roome/roome/be/domain/product/dto/response/RelatedProductResponse.java
+++ b/src/main/java/com/roome/roome/be/domain/product/dto/response/RelatedProductResponse.java
@@ -6,6 +6,8 @@ public record RelatedProductResponse(
         String category,
         String description,
         Integer price,
-        String imageUrl
+        String imageUrl,
+        Integer likeCount,
+        Integer scrapCount
 ) {
 }

--- a/src/main/java/com/roome/roome/be/domain/product/entity/Product.java
+++ b/src/main/java/com/roome/roome/be/domain/product/entity/Product.java
@@ -52,6 +52,9 @@ public class Product extends BaseEntity {
 	@Column(name = "like_count",nullable = false)
 	private Integer likeCount;
 
+	@Column(name = "scrap_count", nullable = false)
+	private Integer scrapCount;
+
 	public void updateName(String name) { this.name = name; }
 	public void updatePrice(Integer price) { this.price = price; }
 	public void updateDescription(String description) { this.description = description; }

--- a/src/main/java/com/roome/roome/be/domain/product/repository/ProductCustomRepositoryImpl.java
+++ b/src/main/java/com/roome/roome/be/domain/product/repository/ProductCustomRepositoryImpl.java
@@ -104,7 +104,9 @@ public class ProductCustomRepositoryImpl implements ProductCustomRepository {
                         tag.name,
                         product.description,
                         product.price,
-                        productImage.imageUrl
+                        productImage.imageUrl,
+                        product.likeCount,
+                        product.scrapCount
                 ))
                 .from(product)
                 .leftJoin(productImage).on(product.id.eq(productImage.product.id).and(productImage.sortOrder.eq(1)))

--- a/src/main/java/com/roome/roome/be/domain/product/service/ProductService.java
+++ b/src/main/java/com/roome/roome/be/domain/product/service/ProductService.java
@@ -7,6 +7,7 @@ import com.roome.roome.be.domain.product.dto.response.*;
 import com.roome.roome.be.domain.product.enums.ProductCategory;
 import com.roome.roome.be.domain.product.enums.TagType;
 import com.roome.roome.be.domain.user.repository.UserLikeProductRepository;
+import com.roome.roome.be.domain.user.repository.UserScrapProductRepository;
 import com.roome.roome.be.domain.user.service.UserViewService;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
@@ -48,6 +49,7 @@ public class ProductService {
     private final S3Service s3Service;
     private final ImageUrlBuilder imageUrlBuilder;
     private final UserViewService userViewService;
+    private final UserScrapProductRepository userScrapProductRepository;
 
     @Value("${storage.defaults.shop-logo}")
     private String defaultShopLogoUrl;
@@ -74,7 +76,7 @@ public class ProductService {
 
     // 상품 상세 조회
     @Transactional
-    public ProductDetailResponse getDetail(Long productId, Long userId) {
+    public ProductDetailResponse getProductDetail(Long productId, Long userId) {
         Product product = getProductById(productId);
 
         // ------------------------------
@@ -116,6 +118,16 @@ public class ProductService {
         var shop = ShopSummaryResponse.from(product.getShop(), logoUrl);
         userViewService.registerUserView(product, userId);
 
+        // ------------------------------
+        // 5) 스크랩, 좋아요 여부
+        // ------------------------------
+        boolean isLiked = false;
+        boolean isScrapped = false;
+        if (userId != null) {
+            isLiked = userLikeProductRepository.existsByUserIdAndProductId(userId, productId);
+            isScrapped = userScrapProductRepository.existsByUserIdAndProductId(userId, productId);
+        }
+
         List<Long> tagIdList = tags.stream().map(ProductTagResponse::id).toList();
 
         List<RelatedProductResponse> relatedProductList =
@@ -124,7 +136,7 @@ public class ProductService {
                         category,
                         tagIdList
                 );
-        return ProductDetailResponse.from(product, thumbnailUrl,category,  images, tags, shop, relatedProductList);
+        return ProductDetailResponse.from(product, thumbnailUrl,category,  images, tags, shop, relatedProductList,isLiked, isScrapped);
     }
 
     // 상품 목록 조회
@@ -184,10 +196,13 @@ public class ProductService {
             ));
 
         Set<Long> likedProductIds = new HashSet<>();
+        Set<Long> scrappedProductIds = new HashSet<>();
         if (userId != null && !productIds.isEmpty()) {
             likedProductIds = userLikeProductRepository.findLikedProductIds(userId, productIds);
+            scrappedProductIds = userScrapProductRepository.findScrappedProductIds(userId, productIds);
         }
         final Set<Long> finalLikedProductIds = likedProductIds;
+        final Set<Long> finalScrappedProductIds = scrappedProductIds;
 
 
         return page.map(p -> {
@@ -196,7 +211,8 @@ public class ProductService {
                 p,
                 cat,
                 imageUrlBuilder,
-                finalLikedProductIds.contains(p.getId())
+                finalLikedProductIds.contains(p.getId()),
+                finalScrappedProductIds.contains(p.getId())
             );
         });
     }

--- a/src/main/java/com/roome/roome/be/domain/reference/dto/response/CommonReferenceInfo.java
+++ b/src/main/java/com/roome/roome/be/domain/reference/dto/response/CommonReferenceInfo.java
@@ -8,6 +8,7 @@ public record CommonReferenceInfo(
         Long userId,
         List<String> imageUrlList,
         Integer scrapCount,
+        Integer likeCount,
         boolean isScrapped,
         boolean isLiked
 ) {

--- a/src/main/java/com/roome/roome/be/domain/reference/service/ReferenceService.java
+++ b/src/main/java/com/roome/roome/be/domain/reference/service/ReferenceService.java
@@ -114,6 +114,7 @@ public class ReferenceService {
                     reference.getUser().getId(),
                     imageUrlList,
                     reference.getScrapCount(),
+                    reference.getLikeCount(),
                     finalScrappedIds.contains(reference.getId()), // isScrapped
                     finalLikedIds.contains(reference.getId())     // isLiked
             );

--- a/src/main/java/com/roome/roome/be/domain/user/repository/UserLikeProductCustomRepositoryImpl.java
+++ b/src/main/java/com/roome/roome/be/domain/user/repository/UserLikeProductCustomRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.roome.roome.be.domain.user.repository;
 import com.querydsl.core.group.GroupBy;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.SimpleExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.roome.roome.be.domain.product.dto.response.CommonProductInfo;
@@ -62,6 +63,10 @@ public class UserLikeProductCustomRepositoryImpl implements UserLikeProductCusto
                                                         tag.type
                                                 )
                                         ),
+                                        product.likeCount,
+                                        product.scrapCount,
+                                        Expressions.TRUE,
+                                        Expressions.FALSE,
                                         product.createdAt,
                                         product.updatedAt
                                 )

--- a/src/main/java/com/roome/roome/be/domain/user/repository/UserLikeProductRepository.java
+++ b/src/main/java/com/roome/roome/be/domain/user/repository/UserLikeProductRepository.java
@@ -17,4 +17,6 @@ public interface UserLikeProductRepository extends JpaRepository<UserLikeProduct
 
     @Query("SELECT ulp.product.id FROM UserLikeProduct ulp WHERE ulp.user.id = :userId AND ulp.product.id IN :productIds")
     Set<Long> findLikedProductIds(@Param("userId") Long userId, @Param("productIds") List<Long> productIds);
+
+    Boolean existsByUserIdAndProductId(Long userId, Long productId);
 }

--- a/src/main/java/com/roome/roome/be/domain/user/repository/UserLikeReferenceCustomRepositoryImpl.java
+++ b/src/main/java/com/roome/roome/be/domain/user/repository/UserLikeReferenceCustomRepositoryImpl.java
@@ -43,6 +43,7 @@ public class UserLikeReferenceCustomRepositoryImpl implements UserLikeReferenceC
                         user.id,
                         list(referenceImage.imageUrl),
                         reference.scrapCount,
+                        reference.likeCount,
                             Expressions.asBoolean(false),            // 6. isScrapped (스크랩 목록 조희니까 True)
                             Expressions.asBoolean(true)
                     )

--- a/src/main/java/com/roome/roome/be/domain/user/repository/UserScrapProductCustomRepositoryImpl.java
+++ b/src/main/java/com/roome/roome/be/domain/user/repository/UserScrapProductCustomRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.roome.roome.be.domain.user.repository;
 import com.querydsl.core.group.GroupBy;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.SimpleExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.roome.roome.be.domain.product.dto.response.CommonProductInfo;
@@ -62,6 +63,10 @@ public class UserScrapProductCustomRepositoryImpl implements UserScrapProductCus
                                                         tag.type
                                                 )
                                         ),
+                                        product.likeCount,
+                                        product.scrapCount,
+                                        Expressions.FALSE,
+                                        Expressions.TRUE,
                                         product.createdAt,
                                         product.updatedAt
                                 )

--- a/src/main/java/com/roome/roome/be/domain/user/repository/UserScrapProductRepository.java
+++ b/src/main/java/com/roome/roome/be/domain/user/repository/UserScrapProductRepository.java
@@ -4,9 +4,18 @@ import com.roome.roome.be.domain.product.entity.Product;
 import com.roome.roome.be.domain.user.entity.User;
 import com.roome.roome.be.domain.user.entity.UserScrapProduct;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 public interface UserScrapProductRepository extends JpaRepository<UserScrapProduct, Long> {
     Optional<UserScrapProduct> findByUserAndProduct(User user, Product product);
+
+    @Query("SELECT usp.product.id FROM UserScrapProduct usp WHERE usp.user.id = :userId And usp.product.id IN :productIds")
+    Set<Long> findScrappedProductIds(@Param("userId") Long userId, @Param("productIds") List<Long> productIds);
+
+    boolean existsByUserIdAndProductId(Long userId, Long productId);
 }

--- a/src/main/java/com/roome/roome/be/domain/user/repository/UserScrapReferenceCustomRepositoryImpl.java
+++ b/src/main/java/com/roome/roome/be/domain/user/repository/UserScrapReferenceCustomRepositoryImpl.java
@@ -37,6 +37,7 @@ public class UserScrapReferenceCustomRepositoryImpl implements UserScrapReferenc
                                         reference.user.id,
                                         GroupBy.list(referenceImage.objectKey),
                                         reference.scrapCount,
+                                        reference.likeCount,
                                         Expressions.asBoolean(true),
                                         Expressions.asBoolean(false)
                                 )

--- a/src/main/java/com/roome/roome/be/domain/user/service/UserLikeService.java
+++ b/src/main/java/com/roome/roome/be/domain/user/service/UserLikeService.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
+import com.roome.roome.be.domain.user.repository.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,11 +23,6 @@ import com.roome.roome.be.domain.user.dto.response.UserLikeReferenceListResponse
 import com.roome.roome.be.domain.user.entity.User;
 import com.roome.roome.be.domain.user.entity.UserLikeProduct;
 import com.roome.roome.be.domain.user.entity.UserLikeReference;
-import com.roome.roome.be.domain.user.repository.UserLikeProductCustomRepository;
-import com.roome.roome.be.domain.user.repository.UserLikeProductRepository;
-import com.roome.roome.be.domain.user.repository.UserLikeReferenceCustomRepository;
-import com.roome.roome.be.domain.user.repository.UserLikeReferenceRepository;
-import com.roome.roome.be.domain.user.repository.UserScrapReferenceRepository; // [추가]
 
 import lombok.RequiredArgsConstructor;
 
@@ -46,6 +42,7 @@ public class UserLikeService {
     private final ReferenceService referenceService;
 
     private final ImageUrlBuilder imageUrlBuilder;
+    private final UserScrapProductRepository userScrapProductRepository;
 
     @Transactional
     public ProductToggleLikeResponse toggleProductLike(Long productId, Long userId) {
@@ -75,8 +72,38 @@ public class UserLikeService {
 
     // 유저가 좋아요를 누른 상품 리스트 조회
     public UserLikeProductListResponse getUserLikedProductList(Long userId) {
-        List<CommonProductInfo> userLikeProductList = userLikeProductCustomRepository.findUserLikeProductListByUserId(userId);
-        return new UserLikeProductListResponse(userLikeProductList);
+        List<CommonProductInfo> rawList = userLikeProductCustomRepository.findUserLikeProductListByUserId(userId);
+
+        List<Long> productIds = rawList.stream()
+                .map(CommonProductInfo::id)
+                .toList();
+
+        Set<Long> scrappedIds = new HashSet<>();
+        if(!productIds.isEmpty()) {
+            scrappedIds = userScrapProductRepository.findScrappedProductIds(userId, productIds);
+        }
+        final Set<Long> finalScrappedIds = scrappedIds;
+
+        List<CommonProductInfo> finalList = rawList.stream()
+                .map(raw -> new CommonProductInfo(
+                        raw.id(),
+                        raw.name(),
+                        raw.category(),
+                        raw.price(),
+                        raw.description(),
+                        raw.productUrl(),
+                        raw.thumbnailKey(),
+                        raw.imageList(),
+                        raw.tagList(),
+                        raw.likeCount(),
+                        raw.scrapCount(),
+                        raw.isLiked(),
+                        finalScrappedIds.contains(raw.id()),
+                        raw.createdAt(),
+                        raw.updatedAt()
+                ))
+                .toList();
+        return new UserLikeProductListResponse(finalList);
     }
 
     // 레퍼런스 좋아요 or 좋아요 취소 기능 구현

--- a/src/main/java/com/roome/roome/be/domain/user/service/UserLikeService.java
+++ b/src/main/java/com/roome/roome/be/domain/user/service/UserLikeService.java
@@ -130,6 +130,7 @@ public class UserLikeService {
                                 .map(imageUrlBuilder::build) // URL 변환
                                 .toList(),
                         raw.scrapCount(),
+                        raw.likeCount(),
                         finalScrappedIds.contains(raw.referenceId()), // isScrapped: DB 조회 결과 반영
                         true
                 ))

--- a/src/main/java/com/roome/roome/be/domain/user/service/UserScrapService.java
+++ b/src/main/java/com/roome/roome/be/domain/user/service/UserScrapService.java
@@ -41,6 +41,7 @@ public class UserScrapService {
     private final ReferenceService referenceService;
 
     private final ImageUrlBuilder imageUrlBuilder;
+    private final UserLikeProductRepository userLikeProductRepository;
 
     // 상품 스크랩 or 스크랩 취소 기능 구현
     @Transactional
@@ -92,8 +93,38 @@ public class UserScrapService {
 
     // 유저가 스크랩한 상품 리스트 조회
     public UserScrappedProductListResponse getUserScrappedProductList(Long userId) {
-        List<CommonProductInfo> userScrappedProductList = userScrapProductCustomRepository.findUserScrappedProductListByUserId(userId);
-        return new UserScrappedProductListResponse(userScrappedProductList);
+        List<CommonProductInfo> rawList = userScrapProductCustomRepository.findUserScrappedProductListByUserId(userId);
+
+        List<Long> productIds = rawList.stream()
+                .map(CommonProductInfo::id)
+                .toList();
+
+        Set<Long> likeIds = new HashSet<>();
+        if(!productIds.isEmpty()) {
+            likeIds = userLikeProductRepository.findLikedProductIds(userId, productIds);
+        }
+
+        final Set<Long> finalLikeIds = likeIds;
+        List<CommonProductInfo> finalList = rawList.stream()
+                .map(raw -> new CommonProductInfo(
+                        raw.id(),
+                        raw.name(),
+                        raw.category(),
+                        raw.price(),
+                        raw.description(),
+                        raw.productUrl(),
+                        raw.thumbnailKey(),
+                        raw.imageList(),
+                        raw.tagList(),
+                        raw.likeCount(),
+                        raw.scrapCount(),
+                        finalLikeIds.contains(raw.id()),
+                        raw.isScrapped(),
+                        raw.createdAt(),
+                        raw.updatedAt()
+                ))
+                .toList();
+        return new UserScrappedProductListResponse(finalList);
     }
 
     // 유저가 스크랩한 레퍼런스 리스트 조회

--- a/src/main/java/com/roome/roome/be/domain/user/service/UserScrapService.java
+++ b/src/main/java/com/roome/roome/be/domain/user/service/UserScrapService.java
@@ -122,6 +122,7 @@ public class UserScrapService {
                                 .map(imageUrlBuilder::build)
                                 .toList(),
                         raw.scrapCount(),
+                        raw.likeCount(),
                         true,
                         finalLikedIds.contains(raw.referenceId())
                 ))

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -40,7 +40,7 @@ spring:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT}
       ssl:
-        enabled: true
+        enabled: false
 
   servlet:
     multipart:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -40,7 +40,7 @@ spring:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT}
       ssl:
-        enabled: false
+        enabled: true
 
   servlet:
     multipart:


### PR DESCRIPTION
## #️⃣ 관련 이슈
closed #92

## 💡 작업 배경
- 상품, 레퍼런스 관련 조회 API에서 응답 값에 좋아요, 스크랩 관련 값 누락

## 🧩 작업 내용
- 유저가 스크랩한 상품, 레퍼런스 리스트 조회 시 응답 값에 좋아요, 스크랩 관련 값 추가
- 유저가 좋아요를 누른 상품, 레퍼런스 리스트 조회 시 응답 값에 좋아요, 스크랩 관련 값 추가
- 상품, 레퍼런스 리스트, 상세 조회 시 응답 값에 좋아요, 스크랩 관련 값 추가

## 📸 스크린샷(선택)
### 유저 스크랩, 좋아요 관련
<img width="1412" height="715" alt="image" src="https://github.com/user-attachments/assets/361bded7-b47e-4446-86be-fd85777d5819" />
<img width="1412" height="704" alt="image" src="https://github.com/user-attachments/assets/11b7d129-5832-4036-98db-9bb1179ce7ec" />
<img width="1412" height="715" alt="image" src="https://github.com/user-attachments/assets/f8091414-ddf8-4cb4-b694-ed0cf869ed1d" />
<img width="1412" height="704" alt="image" src="https://github.com/user-attachments/assets/6d6428b7-2625-4e9c-977d-ea72b68bc761" />

### 상품, 레퍼런스 리스트 or 상세 조회 관련
<img width="1412" height="715" alt="image" src="https://github.com/user-attachments/assets/7c49208d-0d48-4d91-921b-3846ce1b60ce" />
<img width="1412" height="715" alt="image" src="https://github.com/user-attachments/assets/33549eaa-9aa7-453f-84be-14782b1c085d" />
<img width="1412" height="715" alt="image" src="https://github.com/user-attachments/assets/f2f20994-a16d-4f2c-8cc8-6e1c13678e37" />
<img width="1412" height="704" alt="image" src="https://github.com/user-attachments/assets/364cf7d5-80f2-4b99-8511-9c81e636e4b8" />


## 📝 기타
- 기존에 product 테이블에서 scrapCount 컬럼이 없어서 추가했습니다 => 유저가 스크랩을 하거나 좋아요 활동 시 product나 reference테이블 내에서 likeCount or scrapCount 개수를 수정하는 로직이 있는지 확인해봐야 할 것 같아요!
