### PR TITLE
[Feat] 피드/레퍼런스 기본화면 유저 온보딩 값 적용

### DIFF
--- a/src/main/java/com/roome/roome/be/domain/product/mapper/ProductMapper.java
+++ b/src/main/java/com/roome/roome/be/domain/product/mapper/ProductMapper.java
@@ -1,0 +1,95 @@
+package com.roome.roome.be.domain.product.mapper;
+
+import com.roome.roome.be.common.exception.GeneralException;
+import com.roome.roome.be.common.s3.service.ImageUrlBuilder;
+import com.roome.roome.be.common.status.ErrorStatus;
+import com.roome.roome.be.domain.product.dto.response.*;
+import com.roome.roome.be.domain.product.entity.Product;
+import com.roome.roome.be.domain.product.entity.ProductImage;
+import com.roome.roome.be.domain.product.entity.ProductTag;
+import com.roome.roome.be.domain.product.enums.ProductCategory;
+import com.roome.roome.be.domain.product.enums.TagType;
+import com.roome.roome.be.domain.shop.dto.response.ShopSummaryResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class ProductMapper {
+
+    private final ImageUrlBuilder imageUrlBuilder;
+
+    @Value("${storage.defaults.shop-logo}")
+    private String defaultShopLogoUrl;
+
+    // 상세 조회 응답 변환
+    public ProductDetailResponse toDetailResponse(
+            Product product,
+            List<ProductImage> productImages,
+            List<ProductTag> productTags,
+            List<RelatedProductResponse> relatedProducts,
+            boolean isLiked,
+            boolean isScrapped
+    ) {
+        // 1. 이미지 DTO 변환
+        List<ProductImageResponse> imageResponses = productImages.stream()
+                .map(img -> ProductImageResponse.from(img, imageUrlBuilder))
+                .toList();
+
+        // 2. 썸네일 URL 결정
+        String thumbnailUrl = (product.getThumbnailKey() != null)
+                ? imageUrlBuilder.build(product.getThumbnailKey())
+                : (imageResponses.isEmpty() ? null : imageResponses.get(0).url());
+
+        // 3. 태그 DTO 변환 및 카테고리 추출
+        List<ProductTagResponse> tagResponses = productTags.stream()
+                .map(pt -> ProductTagResponse.from(pt.getTag()))
+                .toList();
+
+        ProductCategory category = tagResponses.stream()
+                .filter(t -> t.tagType() == TagType.PRODUCT_TYPE)
+                .findFirst()
+                .map(ProductTagResponse::name)
+                .map(ProductCategory::valueOf)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.PRODUCT_NOT_FOUND));
+
+        // 4. Shop 정보 변환
+        String logoUrl = (product.getShop().getLogoObjectKey() != null && !product.getShop().getLogoObjectKey().isBlank())
+                ? imageUrlBuilder.build(product.getShop().getLogoObjectKey())
+                : defaultShopLogoUrl;
+
+        ShopSummaryResponse shopResponse = ShopSummaryResponse.from(product.getShop(), logoUrl);
+
+        // 5. 최종 응답 생성
+        return ProductDetailResponse.from(
+                product,
+                thumbnailUrl,
+                category,
+                imageResponses,
+                tagResponses,
+                shopResponse,
+                relatedProducts,
+                isLiked,
+                isScrapped
+        );
+    }
+
+    // 목록 조회 아이템 변환
+    public ProductListItemResponse toListItemResponse(
+            Product product,
+            ProductCategory category,
+            boolean isLiked,
+            boolean isScrapped
+    ) {
+        return ProductListItemResponse.from(
+                product,
+                category,
+                imageUrlBuilder,
+                isLiked,
+                isScrapped
+        );
+    }
+}

--- a/src/main/java/com/roome/roome/be/domain/product/service/ProductService.java
+++ b/src/main/java/com/roome/roome/be/domain/product/service/ProductService.java
@@ -6,7 +6,11 @@ import java.util.stream.Collectors;
 import com.roome.roome.be.domain.product.dto.response.*;
 import com.roome.roome.be.domain.product.enums.ProductCategory;
 import com.roome.roome.be.domain.product.enums.TagType;
+import com.roome.roome.be.domain.user.entity.User;
+import com.roome.roome.be.domain.user.entity.UserOnboarding;
 import com.roome.roome.be.domain.user.repository.UserLikeProductRepository;
+import com.roome.roome.be.domain.user.repository.UserOnboardingRepository;
+import com.roome.roome.be.domain.user.repository.UserRepository;
 import com.roome.roome.be.domain.user.repository.UserScrapProductRepository;
 import com.roome.roome.be.domain.user.service.UserViewService;
 import org.springframework.beans.factory.annotation.Value;
@@ -43,6 +47,9 @@ public class ProductService {
     private final ProductImageRepository productImageRepository;
     private final ProductTagRepository productTagRepository;
     private final UserLikeProductRepository userLikeProductRepository;
+
+    private final UserOnboardingRepository userOnboardingRepository;
+    private final UserRepository userRepository;
 
     private final ProductTagService productTagService;
     private final ProductImageService productImageService;
@@ -169,6 +176,27 @@ public class ProductService {
         if (moodTags != null && !moodTags.isEmpty()) tagFilters.put(TagType.MOOD, moodTags);
         if (usageTags != null && !usageTags.isEmpty()) tagFilters.put(TagType.USAGE, usageTags);
 
+        boolean hasExplicitFilters = (keyWord != null && !keyWord.isBlank())
+                || (category != null)
+                || (shopId != null)
+                || (!tagFilters.isEmpty());
+
+        if (!hasExplicitFilters && userId != null) {
+            User user = userRepository.findById(userId)
+                    .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+            UserOnboarding onboarding = userOnboardingRepository.findByUser(user).orElse(null);
+
+            if (onboarding != null) {
+                if (onboarding.getMoodType() != null) {
+                    tagFilters.put(TagType.MOOD, List.of(onboarding.getMoodType().name()));
+                }
+
+                if (onboarding.getSpaceType() != null) {
+                    tagFilters.put(TagType.USAGE, List.of(onboarding.getSpaceType().name()));
+                }
+            }
+        }
         Page<Product> page = productRepository.findByDynamicFilters(
                 shopId,
                 category,

--- a/src/main/java/com/roome/roome/be/domain/product/service/ProductService.java
+++ b/src/main/java/com/roome/roome/be/domain/product/service/ProductService.java
@@ -4,8 +4,11 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import com.roome.roome.be.domain.product.dto.response.*;
+import com.roome.roome.be.domain.product.entity.ProductImage;
+import com.roome.roome.be.domain.product.entity.ProductTag;
 import com.roome.roome.be.domain.product.enums.ProductCategory;
 import com.roome.roome.be.domain.product.enums.TagType;
+import com.roome.roome.be.domain.product.mapper.ProductMapper;
 import com.roome.roome.be.domain.user.entity.User;
 import com.roome.roome.be.domain.user.entity.UserOnboarding;
 import com.roome.roome.be.domain.user.repository.UserLikeProductRepository;
@@ -54,9 +57,10 @@ public class ProductService {
     private final ProductTagService productTagService;
     private final ProductImageService productImageService;
     private final S3Service s3Service;
-    private final ImageUrlBuilder imageUrlBuilder;
     private final UserViewService userViewService;
     private final UserScrapProductRepository userScrapProductRepository;
+
+    private final ProductMapper productMapper;
 
     @Value("${storage.defaults.shop-logo}")
     private String defaultShopLogoUrl;
@@ -81,75 +85,40 @@ public class ProductService {
         return product.getId();
     }
 
-    // 상품 상세 조회
+    // 상품 상세 조회 (리팩토링됨)
     @Transactional
     public ProductDetailResponse getProductDetail(Long productId, Long userId) {
+        // 1. 데이터 조회
         Product product = getProductById(productId);
+        List<ProductImage> images = productImageRepository.findByProductIdOrderBySortOrder(productId);
+        List<ProductTag> productTags = productTagRepository.findByProductIdWithTag(productId);
 
-        // ------------------------------
-        // 1) 대표 이미지 + 상세 이미지
-        // ------------------------------
-        var images = productImageRepository.findByProductIdOrderBySortOrder(productId)
-                .stream()
-                .map(productImage -> ProductImageResponse.from(productImage, imageUrlBuilder))
-                .toList();
-
-        String thumbnailUrl = (product.getThumbnailKey() != null)
-                ? imageUrlBuilder.build(product.getThumbnailKey())
-                : (images.isEmpty() ? null : images.get(0).url());
-
-        // ------------------------------
-        // 2) 상품 태그
-        // ------------------------------
-        var tags = productTagRepository.findByProductIdWithTag(productId).stream()
-                .map(productTag -> ProductTagResponse.from(productTag.getTag()))
-                .toList();
-
-        ProductCategory category = tags.stream()
-            .filter(t -> t.tagType() == TagType.PRODUCT_TYPE)
-            .findFirst()
-            .map(ProductTagResponse::name)
-            .map(ProductCategory::valueOf)
-            .orElseThrow(() -> new GeneralException(ErrorStatus.PRODUCT_NOT_FOUND));
-
-        // ------------------------------
-        // 3) Shop 정보
-        // ------------------------------
-        String logoUrl = (product.getShop().getLogoObjectKey() != null && !product.getShop().getLogoObjectKey().isBlank())
-                ? imageUrlBuilder.build(product.getShop().getLogoObjectKey())
-                : defaultShopLogoUrl;
-
-        // ------------------------------
-        // 4) 유저 조회 로그 저장
-        // ------------------------------
-        var shop = ShopSummaryResponse.from(product.getShop(), logoUrl);
+        // 2. 유저 조회 기록 저장
         userViewService.registerUserView(product, userId);
 
-        // ------------------------------
-        // 5) 스크랩, 좋아요 여부
-        // ------------------------------
-        boolean isLiked = false;
-        boolean isScrapped = false;
-        if (userId != null) {
-            isLiked = userLikeProductRepository.existsByUserIdAndProductId(userId, productId);
-            isScrapped = userScrapProductRepository.existsByUserIdAndProductId(userId, productId);
-        }
+        // 3. 좋아요/스크랩 여부 확인
+        boolean isLiked = (userId != null) && userLikeProductRepository.existsByUserIdAndProductId(userId, productId);
+        boolean isScrapped = (userId != null) && userScrapProductRepository.existsByUserIdAndProductId(userId, productId);
 
-        List<Long> tagIdList = tags.stream().map(ProductTagResponse::id).toList();
+        // 4. 연관 상품 조회
+        ProductCategory category = productTags.stream()
+                .map(pt -> pt.getTag())
+                .filter(t -> t.getType() == TagType.PRODUCT_TYPE)
+                .findFirst()
+                .map(t -> ProductCategory.valueOf(t.getName()))
+                .orElseThrow(() -> new GeneralException(ErrorStatus.PRODUCT_NOT_FOUND));
 
-        List<RelatedProductResponse> relatedProductList =
-                productRepository.findRelatedProductList(
-                        productId,
-                        category,
-                        tagIdList
-                );
-        return ProductDetailResponse.from(product, thumbnailUrl,category,  images, tags, shop, relatedProductList,isLiked, isScrapped);
+        List<Long> tagIdList = productTags.stream().map(pt -> pt.getTag().getId()).toList();
+        List<RelatedProductResponse> relatedProductList = productRepository.findRelatedProductList(productId, category, tagIdList);
+
+        // 5. 변환
+        return productMapper.toDetailResponse(product, images, productTags, relatedProductList, isLiked, isScrapped);
     }
 
     // 상품 목록 조회
     @Transactional(readOnly = true)
     public Page<ProductListItemResponse> getList(
-            Long shopId,                 // 가게 필터
+            Long shopId,
             ProductCategory category,
             List<String> colorTags,
             List<String> materialTags,
@@ -157,17 +126,16 @@ public class ProductService {
             List<String> featureTags,
             List<String> moodTags,
             List<String> usageTags,
-            String match,                // 기본 any
+            String match,
             String keyWord,
             Integer minPrice,
             Integer maxPrice,
             Pageable pageable,
             Long userId
     ) {
-        // match 문자열 정규화
         final String normalizedMatch = (match == null) ? "any" : match.trim().toLowerCase();
 
-        // 모든 태그 파라미터를 Map으로 조립
+        // 1. 태그 필터 구성
         Map<TagType, List<String>> tagFilters = new HashMap<>();
         if (colorTags != null && !colorTags.isEmpty()) tagFilters.put(TagType.COLOR, colorTags);
         if (materialTags != null && !materialTags.isEmpty()) tagFilters.put(TagType.MATERIAL, materialTags);
@@ -176,6 +144,7 @@ public class ProductService {
         if (moodTags != null && !moodTags.isEmpty()) tagFilters.put(TagType.MOOD, moodTags);
         if (usageTags != null && !usageTags.isEmpty()) tagFilters.put(TagType.USAGE, usageTags);
 
+        // 2. 온보딩 필터 적용 로직
         boolean hasExplicitFilters = (keyWord != null && !keyWord.isBlank())
                 || (category != null)
                 || (shopId != null)
@@ -184,65 +153,46 @@ public class ProductService {
         if (!hasExplicitFilters && userId != null) {
             User user = userRepository.findById(userId)
                     .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
-
             UserOnboarding onboarding = userOnboardingRepository.findByUser(user).orElse(null);
 
             if (onboarding != null) {
-                if (onboarding.getMoodType() != null) {
-                    tagFilters.put(TagType.MOOD, List.of(onboarding.getMoodType().name()));
-                }
-
-                if (onboarding.getSpaceType() != null) {
-                    tagFilters.put(TagType.USAGE, List.of(onboarding.getSpaceType().name()));
-                }
+                if (onboarding.getMoodType() != null) tagFilters.put(TagType.MOOD, List.of(onboarding.getMoodType().name()));
+                if (onboarding.getSpaceType() != null) tagFilters.put(TagType.USAGE, List.of(onboarding.getSpaceType().name()));
             }
         }
+
+        // 3. 동적 쿼리 실행
         Page<Product> page = productRepository.findByDynamicFilters(
-                shopId,
-                category,
-                keyWord,
-                minPrice,
-                maxPrice,
-                tagFilters,
-                normalizedMatch,
-                pageable
+                shopId, category, keyWord, minPrice, maxPrice, tagFilters, normalizedMatch, pageable
         );
 
-        if (page.isEmpty())
-            return Page.empty(pageable);
+        if (page.isEmpty()) return Page.empty(pageable);
 
-        List<Long> productIds = page.getContent().stream()
-            .map(Product::getId)
-            .toList();
+        // 4. 부가 데이터 조회 (카테고리, 좋아요/스크랩)
+        List<Long> productIds = page.getContent().stream().map(Product::getId).toList();
 
         Map<Long, ProductCategory> categoryByProductId = productTagRepository
-            .findProductTypeByProductIds(productIds, TagType.PRODUCT_TYPE)
-            .stream()
-            .collect(Collectors.toMap(
-                ProductTagRepository.ProductTypeRow::getProductId,
-                row -> ProductCategory.valueOf(row.getCategoryName())
-            ));
+                .findProductTypeByProductIds(productIds, TagType.PRODUCT_TYPE)
+                .stream()
+                .collect(Collectors.toMap(
+                        ProductTagRepository.ProductTypeRow::getProductId,
+                        row -> ProductCategory.valueOf(row.getCategoryName())
+                ));
 
-        Set<Long> likedProductIds = new HashSet<>();
-        Set<Long> scrappedProductIds = new HashSet<>();
-        if (userId != null && !productIds.isEmpty()) {
-            likedProductIds = userLikeProductRepository.findLikedProductIds(userId, productIds);
-            scrappedProductIds = userScrapProductRepository.findScrappedProductIds(userId, productIds);
-        }
-        final Set<Long> finalLikedProductIds = likedProductIds;
-        final Set<Long> finalScrappedProductIds = scrappedProductIds;
+        Set<Long> likedProductIds = (userId != null && !productIds.isEmpty())
+                ? userLikeProductRepository.findLikedProductIds(userId, productIds)
+                : new HashSet<>();
+        Set<Long> scrappedProductIds = (userId != null && !productIds.isEmpty())
+                ? userScrapProductRepository.findScrappedProductIds(userId, productIds)
+                : new HashSet<>();
 
-
-        return page.map(p -> {
-            ProductCategory cat = categoryByProductId.get(p.getId());
-            return ProductListItemResponse.from(
+        // 5. 변환 (Mapper 위임)
+        return page.map(p -> productMapper.toListItemResponse(
                 p,
-                cat,
-                imageUrlBuilder,
-                finalLikedProductIds.contains(p.getId()),
-                finalScrappedProductIds.contains(p.getId())
-            );
-        });
+                categoryByProductId.get(p.getId()),
+                likedProductIds.contains(p.getId()),
+                scrappedProductIds.contains(p.getId())
+        ));
     }
 
     // 상품 수정

--- a/src/main/java/com/roome/roome/be/domain/reference/controller/ReferenceController.java
+++ b/src/main/java/com/roome/roome/be/domain/reference/controller/ReferenceController.java
@@ -69,7 +69,6 @@ public class ReferenceController {
             @PageableDefault(size = 10, sort = "scrapCount", direction = Sort.Direction.DESC) Pageable pageable
     ){
         searchService.recordSearch(keyWord, userId);
-
         Page<CommonReferenceInfo> response = referenceService.getReferenceList(userId, keyWord, pageable);
 
         return ApiResponse.success(SuccessStatus.GET_REFERENCE_LIST_SUCCESS, response);

--- a/src/main/java/com/roome/roome/be/domain/reference/mapper/ReferenceMapper.java
+++ b/src/main/java/com/roome/roome/be/domain/reference/mapper/ReferenceMapper.java
@@ -1,0 +1,125 @@
+package com.roome.roome.be.domain.reference.mapper;
+
+import com.roome.roome.be.common.s3.service.ImageUrlBuilder;
+import com.roome.roome.be.domain.product.dto.response.ProductTagInfo;
+import com.roome.roome.be.domain.product.entity.Product;
+import com.roome.roome.be.domain.product.entity.ProductImage;
+import com.roome.roome.be.domain.reference.dto.response.*;
+import com.roome.roome.be.domain.reference.entity.Reference;
+import com.roome.roome.be.domain.reference.entity.ReferenceImage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class ReferenceMapper {
+
+    private final ImageUrlBuilder imageUrlBuilder;
+
+    // 목록 조회용 DTO 변환
+    public CommonReferenceInfo toCommonInfo(Reference reference, boolean isScrapped, boolean isLiked) {
+        List<String> imageUrlList = reference.getReferenceImageList().stream()
+                .sorted(Comparator.comparing(ReferenceImage::getSortOrder))
+                .map(refImg -> imageUrlBuilder.build(refImg.getObjectKey()))
+                .toList();
+
+        return new CommonReferenceInfo(
+                reference.getId(),
+                reference.getUser().getNickname(),
+                reference.getUser().getId(),
+                imageUrlList,
+                reference.getScrapCount(),
+                reference.getLikeCount(),
+                isScrapped,
+                isLiked
+        );
+    }
+
+    // 상세 조회용 DTO 변환
+    public ReferenceDetailResponse toDetailResponse(Reference ref, boolean isScrapped, boolean isLiked) {
+        List<String> images = ref.getReferenceImageList().stream()
+                .sorted(Comparator.comparing(ReferenceImage::getSortOrder))
+                .map(ReferenceImage::getObjectKey)
+                .filter(Objects::nonNull)
+                .map(imageUrlBuilder::build)
+                .toList();
+
+        List<ReferenceItemProductInfo> items = ref.getReferenceItemList().stream()
+                .map(com.roome.roome.be.domain.reference.entity.ReferenceItem::getProduct)
+                .filter(Objects::nonNull)
+                .distinct()
+                .map(this::toProductInfo)
+                .toList();
+
+        String userProfileUrl = (ref.getUser().getProfileImage() != null)
+                ? imageUrlBuilder.build(ref.getUser().getProfileImage())
+                : null;
+
+        return new ReferenceDetailResponse(
+                ref.getId(),
+                ref.getName(),
+                ref.getDescription(),
+                images,
+                items,
+                ref.getScrapCount(),
+                ref.getLikeCount(),
+                isScrapped,
+                isLiked,
+                ref.getUser().getNickname(),
+                ref.getUser().getId(),
+                userProfileUrl,
+                ref.getReferenceUrl()
+        );
+    }
+
+    public RelatedReferenceResponse toRelatedResponse(Reference ref, int matchedCount) {
+        String thumbnail = ref.getReferenceImageList().isEmpty()
+                ? null
+                : imageUrlBuilder.build(ref.getReferenceImageList().get(0).getObjectKey());
+
+        return new RelatedReferenceResponse(
+                ref.getId(),
+                thumbnail,
+                ref.getScrapCount(),
+                ref.getUser().getNickname(),
+                ref.getUser().getId(),
+                matchedCount
+        );
+    }
+
+    //  상품 정보 변환 로직
+    private ReferenceItemProductInfo toProductInfo(Product p) {
+        String thumb = null;
+        if (p.getThumbnailKey() != null && !p.getThumbnailKey().isBlank()) {
+            thumb = imageUrlBuilder.build(p.getThumbnailKey());
+        } else if (!p.getProductImageList().isEmpty()) {
+            thumb = p.getProductImageList().stream()
+                    .sorted(Comparator.comparingInt(ProductImage::getSortOrder))
+                    .findFirst()
+                    .map(ProductImage::getImageUrl)
+                    .orElse(null);
+        }
+
+        var tags = p.getProductTagList().stream()
+                .map(pt -> new ProductTagInfo(
+                        pt.getTag().getId(),
+                        pt.getTag().getName(),
+                        pt.getTag().getType()
+                ))
+                .collect(Collectors.toSet());
+
+        return new ReferenceItemProductInfo(
+                p.getId(),
+                p.getName(),
+                p.getPrice(),
+                p.getProductUrl(),
+                thumb,
+                tags
+        );
+    }
+}

--- a/src/main/java/com/roome/roome/be/domain/reference/repository/ReferenceCustomRepository.java
+++ b/src/main/java/com/roome/roome/be/domain/reference/repository/ReferenceCustomRepository.java
@@ -1,9 +1,14 @@
 package com.roome.roome.be.domain.reference.repository;
 
 import com.roome.roome.be.domain.reference.dto.response.CandidateReferenceInfo;
+import com.roome.roome.be.domain.reference.entity.Reference;
 import com.roome.roome.be.domain.reference.enums.ReferenceCategoryMapping;
 import com.roome.roome.be.domain.reference.enums.ReferenceMood;
 import com.roome.roome.be.domain.reference.enums.ReferenceStyle;
+import com.roome.roome.be.domain.user.enums.MoodType;
+import com.roome.roome.be.domain.user.enums.SpaceType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 import java.util.Set;
@@ -22,6 +27,8 @@ public interface ReferenceCustomRepository {
             int minMatchCount,
             int limit
     );
+
+    Page<Reference> findRecommendedList(List<MoodType> moodTypes, List<SpaceType> spaceTypes, Pageable pageable);
 
     record ReferenceMatchResult(
             Long referenceId,

--- a/src/main/java/com/roome/roome/be/domain/reference/repository/ReferenceCustomRepositoryImpl.java
+++ b/src/main/java/com/roome/roome/be/domain/reference/repository/ReferenceCustomRepositoryImpl.java
@@ -3,18 +3,29 @@ package com.roome.roome.be.domain.reference.repository;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.Tuple;
 import com.querydsl.core.group.GroupBy;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.roome.roome.be.domain.product.enums.TagType;
 import com.roome.roome.be.domain.reference.dto.response.CandidateReferenceInfo;
 import com.roome.roome.be.domain.reference.dto.response.ReferenceTagInfo;
+import com.roome.roome.be.domain.reference.entity.Reference;
 import com.roome.roome.be.domain.reference.enums.ReferenceCategoryMapping;
 import com.roome.roome.be.domain.reference.enums.ReferenceMood;
 import com.roome.roome.be.domain.reference.enums.ReferenceStyle;
+import com.roome.roome.be.domain.user.enums.MoodType;
+import com.roome.roome.be.domain.user.enums.SpaceType;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
@@ -23,12 +34,85 @@ import static com.roome.roome.be.domain.product.entity.QTag.tag;
 import static com.roome.roome.be.domain.reference.entity.QReference.reference;
 import static com.roome.roome.be.domain.reference.entity.QReferenceImage.referenceImage;
 import static com.roome.roome.be.domain.reference.entity.QReferenceTag.referenceTag;
+import static com.roome.roome.be.domain.user.entity.QUser.user;
 
 @RequiredArgsConstructor
 @Repository
 public class ReferenceCustomRepositoryImpl implements ReferenceCustomRepository {
 
     private final JPAQueryFactory jpaQueryFactory; // QueryDSL 사용을 위해 주입
+
+    @Override
+    public Page<Reference> findRecommendedList(List<MoodType> moodTypes, List<SpaceType> spaceTypes, Pageable pageable) {
+
+        BooleanBuilder builder = new BooleanBuilder();
+
+        if (moodTypes != null && !moodTypes.isEmpty()) {
+            builder.or(matchesMoodType(moodTypes));
+        }
+        if (spaceTypes != null && !spaceTypes.isEmpty()) {
+            builder.or(matchesSpaceType(spaceTypes));
+        }
+
+        List<Reference> content = jpaQueryFactory
+                .selectFrom(reference)
+                .distinct() // 태그 조인 시 중복 제거
+                .leftJoin(reference.user, user).fetchJoin() // 작성자 정보 N+1 방지
+                .leftJoin(reference.referenceTagList, referenceTag) // 태그 필터링을 위한 조인
+                .leftJoin(referenceTag.tag, tag)
+                .where(builder)
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(getReferenceSort(pageable)) // 정렬 적용
+                .fetch();
+
+        JPAQuery<Long> countQuery = jpaQueryFactory
+                .select(reference.countDistinct())
+                .from(reference)
+                .leftJoin(reference.referenceTagList, referenceTag)
+                .leftJoin(referenceTag.tag, tag)
+                .where(builder);
+
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+    }
+
+    private BooleanExpression matchesMoodType(List<MoodType> moodTypes) {
+        return tag.type.eq(TagType.REFERENCE_MOOD)
+                .and(tag.name.in(moodTypes.stream().map(Enum::name).toList()));
+    }
+
+    private BooleanExpression matchesSpaceType(List<SpaceType> spaceTypes) {
+        return tag.type.eq(TagType.REFERENCE_TYPE)
+                .and(tag.name.in(spaceTypes.stream().map(Enum::name).toList()));
+    }
+
+    private OrderSpecifier<?>[] getReferenceSort(Pageable pageable) {
+        List<OrderSpecifier<?>> orders = new ArrayList<>();
+
+        if (!pageable.getSort().isEmpty()) {
+            for (Sort.Order order : pageable.getSort()) {
+                Order direction = order.getDirection().isAscending() ? Order.ASC : Order.DESC;
+                switch (order.getProperty()) {
+                    case "scrapCount":
+                        orders.add(new OrderSpecifier<>(direction, reference.scrapCount));
+                        break;
+                    case "createdAt":
+                        orders.add(new OrderSpecifier<>(direction, reference.createdAt));
+                        break;
+                    case "id":
+                        orders.add(new OrderSpecifier<>(direction, reference.id));
+                        break;
+                    default:
+                        orders.add(new OrderSpecifier<>(Order.DESC, reference.id));
+                        break;
+                }
+            }
+        } else {
+            orders.add(new OrderSpecifier<>(Order.DESC, reference.scrapCount));
+        }
+
+        return orders.toArray(new OrderSpecifier[0]);
+    }
 
     @Override
     public List<CandidateReferenceInfo> findCandidateReferenceList(

--- a/src/main/java/com/roome/roome/be/domain/reference/service/ReferenceService.java
+++ b/src/main/java/com/roome/roome/be/domain/reference/service/ReferenceService.java
@@ -8,7 +8,11 @@ import com.roome.roome.be.domain.product.entity.Product;
 import com.roome.roome.be.domain.product.entity.ProductImage;
 import com.roome.roome.be.domain.reference.dto.response.*;
 import com.roome.roome.be.domain.reference.repository.ReferenceCustomRepository;
+import com.roome.roome.be.domain.user.entity.UserOnboarding;
+import com.roome.roome.be.domain.user.enums.MoodType;
+import com.roome.roome.be.domain.user.enums.SpaceType;
 import com.roome.roome.be.domain.user.repository.UserLikeReferenceRepository;
+import com.roome.roome.be.domain.user.repository.UserOnboardingRepository;
 import com.roome.roome.be.domain.user.repository.UserScrapReferenceRepository;
 import jakarta.transaction.Transactional;
 import org.springframework.data.domain.Page;
@@ -43,6 +47,7 @@ public class ReferenceService {
     private final ReferenceCustomRepository referenceCustomRepository;
     private final UserLikeReferenceRepository userLikeReferenceRepository;
     private final UserScrapReferenceRepository userScrapReferenceRepository;
+    private final UserOnboardingRepository userOnboardingRepository;
 
     private final S3Service s3Service;
     private final ImageUrlBuilder imageUrlBuilder;
@@ -75,12 +80,31 @@ public class ReferenceService {
     // 레퍼런스 목록 조회
     @Transactional
     public Page<CommonReferenceInfo> getReferenceList(Long userId, String keyWord, Pageable pageable) {
-
         Page<Reference> referencePage;
+
         if (keyWord != null && !keyWord.isBlank()) {
             referencePage = referenceRepository.findByNameContaining(keyWord, pageable);
-        } else {
-            referencePage = referenceRepository.findAll(pageable);
+        }
+        else {
+            User user = userRepository.findById(userId)
+                    .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+            UserOnboarding onboarding = userOnboardingRepository.findByUser(user).orElse(null);
+
+            List<MoodType> moodTypes = new ArrayList<>();
+            List<SpaceType> spaceTypes = new ArrayList<>();
+
+            if (onboarding != null) {
+                if (onboarding.getMoodType() != null) {
+                    moodTypes = List.of(onboarding.getMoodType());
+                }
+
+                if (onboarding.getSpaceType() != null) {
+                    spaceTypes = List.of(onboarding.getSpaceType());
+                }
+            }
+
+            referencePage = referenceCustomRepository.findRecommendedList(moodTypes, spaceTypes, pageable);
         }
 
         if (referencePage.isEmpty()) {
@@ -91,16 +115,8 @@ public class ReferenceService {
                 .map(Reference::getId)
                 .toList();
 
-        Set<Long> scrappedIds = new HashSet<>();
-        Set<Long> likedIds = new HashSet<>();
-
-        if (userId != null && !referenceIds.isEmpty()) {
-            scrappedIds = userScrapReferenceRepository.findScrappedReferenceIds(userId, referenceIds);
-            likedIds = userLikeReferenceRepository.findLikedReferenceIds(userId, referenceIds); // Repository 생성 필요
-        }
-
-        final Set<Long> finalScrappedIds = scrappedIds;
-        final Set<Long> finalLikedIds = likedIds;
+        Set<Long> scrappedIds = userScrapReferenceRepository.findScrappedReferenceIds(userId, referenceIds);
+        Set<Long> likedIds = userLikeReferenceRepository.findLikedReferenceIds(userId, referenceIds);
 
         return referencePage.map(reference -> {
             List<String> imageUrlList = reference.getReferenceImageList().stream()
@@ -115,8 +131,8 @@ public class ReferenceService {
                     imageUrlList,
                     reference.getScrapCount(),
                     reference.getLikeCount(),
-                    finalScrappedIds.contains(reference.getId()), // isScrapped
-                    finalLikedIds.contains(reference.getId())     // isLiked
+                    scrappedIds.contains(reference.getId()), // isScrapped
+                    likedIds.contains(reference.getId())     // isLiked
             );
         });
     }

--- a/src/main/java/com/roome/roome/be/domain/reference/service/ReferenceService.java
+++ b/src/main/java/com/roome/roome/be/domain/reference/service/ReferenceService.java
@@ -7,6 +7,7 @@ import com.roome.roome.be.domain.product.dto.response.ProductTagInfo;
 import com.roome.roome.be.domain.product.entity.Product;
 import com.roome.roome.be.domain.product.entity.ProductImage;
 import com.roome.roome.be.domain.reference.dto.response.*;
+import com.roome.roome.be.domain.reference.mapper.ReferenceMapper;
 import com.roome.roome.be.domain.reference.repository.ReferenceCustomRepository;
 import com.roome.roome.be.domain.user.entity.UserOnboarding;
 import com.roome.roome.be.domain.user.enums.MoodType;
@@ -49,8 +50,9 @@ public class ReferenceService {
     private final UserScrapReferenceRepository userScrapReferenceRepository;
     private final UserOnboardingRepository userOnboardingRepository;
 
+    private final ReferenceMapper referenceMapper;
+
     private final S3Service s3Service;
-    private final ImageUrlBuilder imageUrlBuilder;
 
     // 레퍼런스 등록
     public void registerReference(Long userId, List<MultipartFile> images) {
@@ -80,61 +82,43 @@ public class ReferenceService {
     // 레퍼런스 목록 조회
     @Transactional
     public Page<CommonReferenceInfo> getReferenceList(Long userId, String keyWord, Pageable pageable) {
-        Page<Reference> referencePage;
 
+        // 1. 조회 대상 결정 (검색 vs 추천)
+        Page<Reference> referencePage;
         if (keyWord != null && !keyWord.isBlank()) {
             referencePage = referenceRepository.findByNameContaining(keyWord, pageable);
-        }
-        else {
-            User user = userRepository.findById(userId)
-                    .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
-
-            UserOnboarding onboarding = userOnboardingRepository.findByUser(user).orElse(null);
-
-            List<MoodType> moodTypes = new ArrayList<>();
-            List<SpaceType> spaceTypes = new ArrayList<>();
-
-            if (onboarding != null) {
-                if (onboarding.getMoodType() != null) {
-                    moodTypes = List.of(onboarding.getMoodType());
-                }
-
-                if (onboarding.getSpaceType() != null) {
-                    spaceTypes = List.of(onboarding.getSpaceType());
-                }
-            }
-
-            referencePage = referenceCustomRepository.findRecommendedList(moodTypes, spaceTypes, pageable);
+        } else {
+            referencePage = getRecommendedReferences(userId, pageable);
         }
 
         if (referencePage.isEmpty()) {
             return Page.empty(pageable);
         }
 
-        List<Long> referenceIds = referencePage.getContent().stream()
-                .map(Reference::getId)
-                .toList();
+        // 2. 좋아요/스크랩 정보 조회
+        List<Long> referenceIds = referencePage.getContent().stream().map(Reference::getId).toList();
+        Set<Long> scrappedIds = (userId != null) ? userScrapReferenceRepository.findScrappedReferenceIds(userId, referenceIds) : new HashSet<>();
+        Set<Long> likedIds = (userId != null) ? userLikeReferenceRepository.findLikedReferenceIds(userId, referenceIds) : new HashSet<>();
 
-        Set<Long> scrappedIds = userScrapReferenceRepository.findScrappedReferenceIds(userId, referenceIds);
-        Set<Long> likedIds = userLikeReferenceRepository.findLikedReferenceIds(userId, referenceIds);
+        // 3. 변환
+        return referencePage.map(ref ->
+                referenceMapper.toCommonInfo(ref, scrappedIds.contains(ref.getId()), likedIds.contains(ref.getId()))
+        );
+    }
 
-        return referencePage.map(reference -> {
-            List<String> imageUrlList = reference.getReferenceImageList().stream()
-                    .sorted(Comparator.comparing(ReferenceImage::getSortOrder))
-                    .map(refImg -> imageUrlBuilder.build(refImg.getObjectKey()))
-                    .toList();
+    private Page<Reference> getRecommendedReferences(Long userId, Pageable pageable) {
+        if (userId == null) return referenceRepository.findAll(pageable); // 비로그인 대비(혹은 예외)
 
-            return new CommonReferenceInfo(
-                    reference.getId(),
-                    reference.getUser().getNickname(),
-                    reference.getUser().getId(),
-                    imageUrlList,
-                    reference.getScrapCount(),
-                    reference.getLikeCount(),
-                    scrappedIds.contains(reference.getId()), // isScrapped
-                    likedIds.contains(reference.getId())     // isLiked
-            );
-        });
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+        UserOnboarding onboarding = userOnboardingRepository.findByUser(user).orElse(null);
+
+        List<MoodType> moodTypes = (onboarding != null && onboarding.getMoodType() != null)
+                ? List.of(onboarding.getMoodType()) : Collections.emptyList();
+        List<SpaceType> spaceTypes = (onboarding != null && onboarding.getSpaceType() != null)
+                ? List.of(onboarding.getSpaceType()) : Collections.emptyList();
+
+        return referenceCustomRepository.findRecommendedList(moodTypes, spaceTypes, pageable);
     }
 
     public Reference findReferenceById(Long referenceId) {
@@ -157,81 +141,10 @@ public class ReferenceService {
         Reference ref = referenceRepository.findById(referenceId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.REFERENCE_NOT_FOUND));
 
-        List<String> images = ref.getReferenceImageList().stream()
-                .sorted(Comparator.comparing(ReferenceImage::getSortOrder))
-                .map(ReferenceImage::getObjectKey)
-                .filter(Objects::nonNull)
-                .map(imageUrlBuilder::build)
-                .toList();
+        boolean isLiked = (userId != null) && userLikeReferenceRepository.existsByUserIdAndReferenceId(userId, referenceId);
+        boolean isScrapped = (userId != null) && userScrapReferenceRepository.existsByUserIdAndReferenceId(userId, referenceId);
 
-        List<ReferenceItemProductInfo> items = ref.getReferenceItemList().stream()
-                .map(com.roome.roome.be.domain.reference.entity.ReferenceItem::getProduct)
-                .filter(Objects::nonNull)
-                .collect(Collectors.toMap(
-                        Product::getId,
-                        product -> product,
-                        (existing, replacement) -> existing,
-                        LinkedHashMap::new
-                ))
-                .values().stream()
-                .map(p -> {
-                    String thumb = null;
-                    if (p.getThumbnailKey() != null && !p.getThumbnailKey().isBlank()) {
-                        thumb = imageUrlBuilder.build(p.getThumbnailKey());
-                    } else if (!p.getProductImageList().isEmpty()) {
-                        thumb = p.getProductImageList().stream()
-                                .sorted(Comparator.comparingInt(ProductImage::getSortOrder))
-                                .findFirst()
-                                .map(ProductImage::getImageUrl)
-                                .orElse(null);
-                    }
-
-                    Set<ProductTagInfo> tags = p.getProductTagList().stream()
-                            .map(pt -> new ProductTagInfo(
-                                    pt.getTag().getId(),
-                                    pt.getTag().getName(),
-                                    pt.getTag().getType()
-                            ))
-                            .collect(Collectors.toSet());
-
-                    return new ReferenceItemProductInfo(
-                            p.getId(),
-                            p.getName(),
-                            p.getPrice(),
-                            p.getProductUrl(),
-                            thumb,
-                            tags
-                    );
-                })
-                .toList();
-
-        boolean isLiked = false;
-        boolean isScrapped = false;
-
-        if (userId != null) {
-            isLiked = userLikeReferenceRepository.existsByUserIdAndReferenceId(userId, referenceId);
-            isScrapped = userScrapReferenceRepository.existsByUserIdAndReferenceId(userId, referenceId);
-        }
-
-        String userProfileUrl = (ref.getUser().getProfileImage() != null)
-                ? imageUrlBuilder.build(ref.getUser().getProfileImage())
-                : null;
-
-        return new ReferenceDetailResponse(
-                ref.getId(),
-                ref.getName(),
-                ref.getDescription(),
-                images,
-                items,
-                ref.getScrapCount(),
-                ref.getLikeCount(),
-                isScrapped,
-                isLiked,
-                ref.getUser().getNickname(),
-                ref.getUser().getId(),
-                userProfileUrl,
-                ref.getReferenceUrl()
-        );
+        return referenceMapper.toDetailResponse(ref, isScrapped, isLiked);
     }
 
     // 상품 관련 레퍼런스 조회
@@ -252,20 +165,7 @@ public class ReferenceService {
         return referenceIds.stream()
                 .map(id -> references.stream().filter(ref -> ref.getId().equals(id)).findFirst().orElse(null))
                 .filter(Objects::nonNull)
-                .map(ref -> {
-                    String thumbnail = ref.getReferenceImageList().isEmpty()
-                            ? null
-                            : imageUrlBuilder.build(ref.getReferenceImageList().get(0).getObjectKey());
-
-                    return new RelatedReferenceResponse(
-                            ref.getId(),
-                            thumbnail,
-                            ref.getScrapCount(),
-                            ref.getUser().getNickname(),
-                            ref.getUser().getId(),
-                            matchCountMap.get(ref.getId())
-                    );
-                })
+                .map(ref -> referenceMapper.toRelatedResponse(ref, matchCountMap.get(ref.getId())))
                 .toList();
     }
 }

--- a/src/main/java/com/roome/roome/be/domain/user/enums/Gender.java
+++ b/src/main/java/com/roome/roome/be/domain/user/enums/Gender.java
@@ -8,7 +8,7 @@ import lombok.RequiredArgsConstructor;
 public enum Gender {
     FEMALE("여성"),
     MALE("남성"),
-    OTHER("기타");
+    OTHER("공개 안함");
 
     private final String description;
 }

--- a/src/main/java/com/roome/roome/be/domain/user/enums/MoodType.java
+++ b/src/main/java/com/roome/roome/be/domain/user/enums/MoodType.java
@@ -7,10 +7,10 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum MoodType {
     COZY("아늑한"),
-    SIMPLE("단순한"),
+    SIMPLE("심플한"),
     SNUG("포근한"),
     NEAT("깔끔한"),
-    CHIC("세련된"),
+    CHIC("시크한"),
     CUTE("귀여운");
 
     private final String description;


### PR DESCRIPTION
## #️⃣ 관련 이슈
closed #96 

## 💡 작업 배경


## 🧩 작업 내용
목록 조회 API 호출 시 검색 조건이 없는 경우, 로그인한 유저의 온보딩 정보 필터 조건에 자동 적용 


## 📸 스크린샷(선택)
- 피드 화면 기본 조회
<img width="2858" height="1176" alt="image" src="https://github.com/user-attachments/assets/c3627576-e176-4de5-a30c-349c848b9863" />

- shop 화면 기본 조회
<img width="1415" height="598" alt="image" src="https://github.com/user-attachments/assets/6f260980-6dcb-4ba9-9bf8-fe587f229add" />


## 📝 기타
 Reference, product 서비스 로직이 너무 복잡해져서 dto 변환 부분은 mapper class로 분리해서 리팩토링 했습니다..!