### PR TITLE
[Fix] 상품, 레퍼런스 전체 조회시 온보딩 매칭 결과 없는 사용자의 경우 빈값 나오는 오류 해결

### DIFF
--- a/src/main/java/com/roome/roome/be/domain/product/controller/ProductController.java
+++ b/src/main/java/com/roome/roome/be/domain/product/controller/ProductController.java
@@ -137,11 +137,11 @@ public class ProductController {
 			@RequestParam(required = false) String keyWord,
 			@RequestParam(required = false) Integer minPrice,
 			@RequestParam(required = false) Integer maxPrice,
-
+			@RequestParam(required = false) List<String> sort,
 			@AuthenticationPrincipal Long userId,
 
 			@ParameterObject
-			@PageableDefault(size = 20, sort = "id", direction = Sort.Direction.DESC) Pageable pageable
+			@PageableDefault(size = 20) Pageable pageable
 	) {
 		searchService.recordSearch(keyWord, userId);
 		var page = productService.getList(shopId, category, colorTags, materialTags, styleTags, featureTags, moodTags,usageTags, match, keyWord, minPrice, maxPrice, pageable, userId);

--- a/src/main/java/com/roome/roome/be/domain/product/repository/ProductCustomRepository.java
+++ b/src/main/java/com/roome/roome/be/domain/product/repository/ProductCustomRepository.java
@@ -7,6 +7,7 @@ import com.roome.roome.be.domain.product.enums.ProductCategory;
 import com.roome.roome.be.domain.product.enums.TagType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 
 import java.util.List;
 import java.util.Map;
@@ -43,4 +44,45 @@ public interface ProductCustomRepository {
             Integer minBudget,
             List<String> preferredColors
     );
+
+    List<Product> findSliceByDynamicFilters(
+        Long shopId,
+        ProductCategory category,
+        String keyWord,
+        Integer minPrice,
+        Integer maxPrice,
+        Map<TagType, List<String>> tagFilters,
+        String match,
+        List<Long> excludeIds,
+        long offset,
+        int limit,
+        Sort sort
+    );
+
+    // 비추천 가져오기
+    List<Product> findNonRecommendedSliceByFilters(
+        Long shopId,
+        ProductCategory category,
+        String keyWord,
+        Integer minPrice,
+        Integer maxPrice,
+        Map<TagType, List<String>> baseFilters,
+        String baseMatch,
+        Map<TagType, List<String>> recommendedFilters,
+        String recommendedMatch,
+        long offset,
+        int limit,
+        Sort sort
+    );
+
+    long countByDynamicFilters(
+        Long shopId,
+        ProductCategory category,
+        String keyWord,
+        Integer minPrice,
+        Integer maxPrice,
+        Map<TagType, List<String>> tagFilters,
+        String match
+    );
+
 }

--- a/src/main/java/com/roome/roome/be/domain/product/repository/ProductCustomRepositoryImpl.java
+++ b/src/main/java/com/roome/roome/be/domain/product/repository/ProductCustomRepositoryImpl.java
@@ -119,6 +119,76 @@ public class ProductCustomRepositoryImpl implements ProductCustomRepository {
                 .fetch();
     }
 
+    @Override
+    public long countByDynamicFilters(
+        Long shopId,
+        ProductCategory category,
+        String keyWord,
+        Integer minPrice,
+        Integer maxPrice,
+        Map<TagType, List<String>> tagFilters,
+        String match
+    ) {
+        Long cnt = jpaQueryFactory
+            .select(product.countDistinct())
+            .from(product)
+            .where(
+                shopIdEq(shopId),
+                categoryEq(category),
+                nameContains(keyWord),
+                priceGoe(minPrice),
+                priceLoe(maxPrice),
+                tagFilter(tagFilters, match)
+            )
+            .fetchOne();
+
+        return (cnt == null) ? 0L : cnt;
+    }
+
+    @Override
+    public List<Product> findSliceByDynamicFilters(
+        Long shopId,
+        ProductCategory category,
+        String keyWord,
+        Integer minPrice,
+        Integer maxPrice,
+        Map<TagType, List<String>> tagFilters,
+        String match,
+        List<Long> excludeIds,
+        long offset,
+        int limit,
+        Sort sort
+    ) {
+        JPAQuery<Product> query = jpaQueryFactory
+            .selectFrom(product)
+            .leftJoin(product.shop, shop).fetchJoin()
+            .distinct();
+
+        BooleanExpression excludeCond = disclosureSafeNotEmpty(excludeIds)
+            ? product.id.notIn(excludeIds)
+            : null;
+
+        query.where(
+            shopIdEq(shopId),
+            categoryEq(category),
+            nameContains(keyWord),
+            priceGoe(minPrice),
+            priceLoe(maxPrice),
+            tagFilter(tagFilters, match),
+            excludeCond
+        );
+
+        applySort(query, sort);
+
+        query.offset(offset).limit(limit);
+
+        return query.fetch();
+    }
+
+    private boolean disclosureSafeNotEmpty(List<?> list) {
+        return list != null && !list.isEmpty();
+    }
+
     private BooleanExpression shopIdEq(Long shopId) {
         return shopId != null ? product.shop.id.eq(shopId) : null;
     }
@@ -136,6 +206,57 @@ public class ProductCustomRepositoryImpl implements ProductCustomRepository {
                 tag.name.eq(category.name())
             )
             .exists();
+    }
+    @Override
+    public List<Product> findNonRecommendedSliceByFilters(
+        Long shopId,
+        ProductCategory category,
+        String keyWord,
+        Integer minPrice,
+        Integer maxPrice,
+        Map<TagType, List<String>> baseFilters,
+        String baseMatch,
+        Map<TagType, List<String>> recommendedFilters,
+        String recommendedMatch,
+        long offset,
+        int limit,
+        Sort sort
+    ) {
+        if (limit <= 0) return List.of();
+
+        JPAQuery<Product> query = jpaQueryFactory
+            .selectFrom(product)
+            .leftJoin(product.shop, shop).fetchJoin()
+            .distinct();
+
+        query.where(
+            shopIdEq(shopId),
+            categoryEq(category),
+            nameContains(keyWord),
+            priceGoe(minPrice),
+            priceLoe(maxPrice),
+            tagFilter(baseFilters, baseMatch),
+            excludeRecommendedByFilters(recommendedFilters, recommendedMatch) // ✅ 핵심
+        );
+
+        applySort(query, sort);
+
+        query.offset(offset).limit(limit);
+
+        return query.fetch();
+    }
+
+
+    // 추천 조건을 만족하는 상품은 제외
+    private BooleanExpression excludeRecommendedByFilters(
+        Map<TagType, List<String>> recommendedFilters,
+        String recommendedMatch
+    ) {
+        if (recommendedFilters == null || recommendedFilters.isEmpty()) return null;
+
+        BooleanExpression isRecommended = tagFilter(recommendedFilters, recommendedMatch);
+
+        return (isRecommended == null) ? null : isRecommended.not();
     }
 
     private BooleanExpression nameContains(String keyWord) {
@@ -231,23 +352,13 @@ public class ProductCustomRepositoryImpl implements ProductCustomRepository {
 
     private void applySort(JPAQuery<Product> query, Pageable pageable) {
 
-        // 기본 정렬
-        if (pageable.getSort().isUnsorted()) {
-            query.orderBy(product.id.desc());
-            return;
-        }
-
-        boolean hasIdSort = false;
 
         for (Sort.Order o : pageable.getSort()) {
             String prop = o.getProperty();
             Order dir = o.isAscending() ? Order.ASC : Order.DESC;
 
             OrderSpecifier<?> spec = switch (prop) {
-                case "id" -> {
-                    hasIdSort = true;
-                    yield new OrderSpecifier<>(dir, product.id);
-                }
+                case "id" -> new OrderSpecifier<>(dir, product.id);
                 case "price" -> new OrderSpecifier<>(dir, product.price);
                 case "createdAt" -> new OrderSpecifier<>(dir, product.createdAt);
                 case "popularity" -> new OrderSpecifier<>(dir, product.likeCount); //좋아요 순
@@ -257,8 +368,22 @@ public class ProductCustomRepositoryImpl implements ProductCustomRepository {
             if (spec != null) query.orderBy(spec);
         }
 
-        if (!hasIdSort) {
-            query.orderBy(product.id.desc());
+    }
+
+    private void applySort(JPAQuery<Product> query, Sort sort) {
+
+        for (Sort.Order o : sort) {
+            String prop = o.getProperty();
+            Order dir = o.isAscending() ? Order.ASC : Order.DESC;
+
+            OrderSpecifier<?> spec = switch (prop) {
+                case "id" ->new OrderSpecifier<>(dir, product.id);
+                case "price" -> new OrderSpecifier<>(dir, product.price);
+                case "createdAt" -> new OrderSpecifier<>(dir, product.createdAt);
+                case "popularity" -> new OrderSpecifier<>(dir, product.likeCount);
+                default -> null;
+            };
+            if (spec != null) query.orderBy(spec);
         }
     }
 

--- a/src/main/java/com/roome/roome/be/domain/product/service/ProductService.java
+++ b/src/main/java/com/roome/roome/be/domain/product/service/ProductService.java
@@ -1,9 +1,33 @@
 package com.roome.roome.be.domain.product.service;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
-import com.roome.roome.be.domain.product.dto.response.*;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+import com.roome.roome.be.common.exception.GeneralException;
+import com.roome.roome.be.common.s3.service.S3Service;
+import com.roome.roome.be.common.status.ErrorStatus;
+import com.roome.roome.be.domain.product.dto.request.RegisterProductRequest;
+import com.roome.roome.be.domain.product.dto.request.UpdateProductRequest;
+import com.roome.roome.be.domain.product.dto.response.CandidateProductInfo;
+import com.roome.roome.be.domain.product.dto.response.ProductDetailResponse;
+import com.roome.roome.be.domain.product.dto.response.ProductListItemResponse;
+import com.roome.roome.be.domain.product.dto.response.RelatedProductResponse;
+import com.roome.roome.be.domain.product.entity.Product;
 import com.roome.roome.be.domain.product.entity.ProductImage;
 import com.roome.roome.be.domain.product.entity.ProductTag;
 import com.roome.roome.be.domain.product.enums.ProductCategory;
@@ -11,38 +35,21 @@ import com.roome.roome.be.domain.product.enums.ProductType;
 import com.roome.roome.be.domain.product.enums.ProductTypeMapper;
 import com.roome.roome.be.domain.product.enums.TagType;
 import com.roome.roome.be.domain.product.mapper.ProductMapper;
+import com.roome.roome.be.domain.product.repository.ProductImageRepository;
+import com.roome.roome.be.domain.product.repository.ProductRepository;
+import com.roome.roome.be.domain.product.repository.ProductTagRepository;
+import com.roome.roome.be.domain.shop.repository.ShopRepository;
 import com.roome.roome.be.domain.user.entity.User;
 import com.roome.roome.be.domain.user.entity.UserOnboarding;
+import com.roome.roome.be.domain.user.repository.UserLikeProductCustomRepositoryImpl;
 import com.roome.roome.be.domain.user.repository.UserLikeProductRepository;
 import com.roome.roome.be.domain.user.repository.UserOnboardingRepository;
 import com.roome.roome.be.domain.user.repository.UserRepository;
 import com.roome.roome.be.domain.user.repository.UserScrapProductRepository;
 import com.roome.roome.be.domain.user.service.UserViewService;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.transaction.support.TransactionSynchronization;
-import org.springframework.transaction.support.TransactionSynchronizationManager;
-
-import com.roome.roome.be.common.exception.GeneralException;
-import com.roome.roome.be.common.s3.service.ImageUrlBuilder;
-import com.roome.roome.be.common.s3.service.S3Service;
-import com.roome.roome.be.common.status.ErrorStatus;
-import com.roome.roome.be.domain.product.dto.request.RegisterProductRequest;
-import com.roome.roome.be.domain.product.dto.request.UpdateProductRequest;
-import com.roome.roome.be.domain.product.entity.Product;
-import com.roome.roome.be.domain.product.repository.ProductImageRepository;
-import com.roome.roome.be.domain.product.repository.ProductRepository;
-import com.roome.roome.be.domain.product.repository.ProductTagRepository;
-import com.roome.roome.be.domain.shop.dto.response.ShopSummaryResponse;
-import com.roome.roome.be.domain.shop.repository.ShopRepository;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-
-import static java.util.stream.Collectors.toList;
 
 @Slf4j
 @Service
@@ -65,6 +72,7 @@ public class ProductService {
     private final UserScrapProductRepository userScrapProductRepository;
 
     private final ProductMapper productMapper;
+    private final UserLikeProductCustomRepositoryImpl userLikeProductCustomRepositoryImpl;
 
     @Value("${storage.defaults.shop-logo}")
     private String defaultShopLogoUrl;
@@ -138,50 +146,128 @@ public class ProductService {
             Long userId
     ) {
         final String normalizedMatch = (match == null) ? "any" : match.trim().toLowerCase();
+        final int pageSize = pageable.getPageSize();
+        final long offset = pageable.getOffset();
 
-        // 1. 태그 필터 구성
-        Map<TagType, List<String>> tagFilters = new HashMap<>();
-        if (colorTags != null && !colorTags.isEmpty()) tagFilters.put(TagType.COLOR, colorTags);
-        if (materialTags != null && !materialTags.isEmpty()) tagFilters.put(TagType.MATERIAL, materialTags);
-        if (styleTags != null && !styleTags.isEmpty()) tagFilters.put(TagType.STYLE, styleTags);
-        if (featureTags != null && !featureTags.isEmpty()) tagFilters.put(TagType.FEATURE, featureTags);
-        if (moodTags != null && !moodTags.isEmpty()) tagFilters.put(TagType.MOOD, moodTags);
-        if (usageTags != null && !usageTags.isEmpty()) tagFilters.put(TagType.USAGE, usageTags);
+        if (pageSize <= 0) throw new GeneralException(ErrorStatus.BAD_REQUEST);
 
-        // 2. 온보딩 필터 적용 로직
+        // sort 파라미터를 명시했는지 여부
+        boolean hasSortParam = !pageable.getSort().isUnsorted();
+
+        Map<TagType, List<String>> explicitTagFilters = new HashMap<>();
+        if (colorTags != null && !colorTags.isEmpty()) explicitTagFilters.put(TagType.COLOR, colorTags);
+        if (materialTags != null && !materialTags.isEmpty()) explicitTagFilters.put(TagType.MATERIAL, materialTags);
+        if (styleTags != null && !styleTags.isEmpty()) explicitTagFilters.put(TagType.STYLE, styleTags);
+        if (featureTags != null && !featureTags.isEmpty()) explicitTagFilters.put(TagType.FEATURE, featureTags);
+        if (moodTags != null && !moodTags.isEmpty()) explicitTagFilters.put(TagType.MOOD, moodTags);
+        if (usageTags != null && !usageTags.isEmpty()) explicitTagFilters.put(TagType.USAGE, usageTags);
+
         boolean hasExplicitFilters = (keyWord != null && !keyWord.isBlank())
-                || (category != null)
-                || (shopId != null)
-                || (!tagFilters.isEmpty());
+            || (category != null)
+            || (shopId != null)
+            || (!explicitTagFilters.isEmpty());
 
-        if (!hasExplicitFilters && userId != null) {
-            User user = userRepository.findById(userId)
-                    .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
-            UserOnboarding onboarding = userOnboardingRepository.findByUser(user).orElse(null);
-
-            if (onboarding != null) {
-                if (onboarding.getMoodType() != null) tagFilters.put(TagType.MOOD, List.of(onboarding.getMoodType().name()));
-                if (onboarding.getSpaceType() != null) tagFilters.put(TagType.USAGE, List.of(onboarding.getSpaceType().name()));
-            }
+        // 필터 있거나 sort 있으면  추천 스킵
+        if (hasExplicitFilters || hasSortParam ) {
+            Page<Product> page = productRepository.findByDynamicFilters(
+                shopId, category, keyWord, minPrice, maxPrice,
+                explicitTagFilters, normalizedMatch, pageable
+            );
+            if (page.isEmpty()) return Page.empty(pageable);
+            return mapToListItemPage(page, userId);
         }
 
-        // 3. 동적 쿼리 실행
-        Page<Product> page = productRepository.findByDynamicFilters(
-                shopId, category, keyWord, minPrice, maxPrice, tagFilters, normalizedMatch, pageable
+        //온보딩 추천 상품 보여주는 로직
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+        UserOnboarding onboarding = userOnboardingRepository.findByUser(user).orElse(null);
+
+        Map<TagType, List<String>> onboardingFilters = new HashMap<>();
+        if (onboarding != null) {
+            if (onboarding.getMoodType() != null) onboardingFilters.put(TagType.MOOD, List.of(onboarding.getMoodType().name()));
+            if (onboarding.getSpaceType() != null) onboardingFilters.put(TagType.USAGE, List.of(onboarding.getSpaceType().name()));
+        }
+
+        if (onboardingFilters.isEmpty()) {
+            Page<Product> page = productRepository.findByDynamicFilters(
+                shopId, category, keyWord, minPrice, maxPrice,
+                Map.of(), normalizedMatch, pageable
+            );
+            if (page.isEmpty()) return Page.empty(pageable);
+            return mapToListItemPage(page, userId);
+        }
+
+        // 온보딩 추천 +. 추천 이어서 나머지 모두 id desc로 정렬(기본 정렬)
+        Sort bucketSort = Sort.by(Sort.Direction.DESC, "id");
+
+        long recTotal = productRepository.countByDynamicFilters(
+            shopId, category, keyWord, minPrice, maxPrice,
+            onboardingFilters, "any"
         );
 
-        if (page.isEmpty()) return Page.empty(pageable);
+        long totalAll = productRepository.countByDynamicFilters(
+            shopId, category, keyWord, minPrice, maxPrice,
+            Map.of(), normalizedMatch
+        );
 
-        // 4. 부가 데이터 조회 (카테고리, 좋아요/스크랩)
-        List<Long> productIds = page.getContent().stream().map(Product::getId).toList();
+        long recStart = offset;
+        int recLimit = (recStart < recTotal)
+            ? (int) Math.min(pageSize, recTotal - recStart)
+            : 0;
+
+        List<Product> recommended = (recLimit > 0)
+            ? productRepository.findSliceByDynamicFilters(
+            shopId, category, keyWord, minPrice, maxPrice,
+            onboardingFilters, "any",
+            Collections.emptyList(),
+            recStart,
+            recLimit,
+            bucketSort
+        )
+            : List.of();
+
+        int remain = pageSize - recommended.size();
+        if (remain <= 0) {
+            return mapToListItemPage(recommended, pageable, totalAll, userId);
+        }
+
+        long nonRecOffset = Math.max(0, offset - recTotal);
+
+        List<Product> nonRecommended = productRepository.findNonRecommendedSliceByFilters(
+            shopId, category, keyWord, minPrice, maxPrice,
+            Map.of(), normalizedMatch,
+            onboardingFilters, "any",
+            nonRecOffset,
+            remain,
+            bucketSort
+        );
+
+        List<Product> mixed = new ArrayList<>(pageSize);
+        mixed.addAll(recommended);
+        mixed.addAll(nonRecommended);
+
+        if (mixed.isEmpty()) return Page.empty(pageable);
+        return mapToListItemPage(mixed, pageable, totalAll, userId);
+    }
+
+
+
+    private Page<ProductListItemResponse> mapToListItemPage(Page<Product> page, Long userId) {
+        List<Product> products = page.getContent();
+        return mapToListItemPage(products, page.getPageable(), page.getTotalElements(), userId);
+    }
+
+
+    private Page<ProductListItemResponse> mapToListItemPage(List<Product> products, Pageable pageable, long total, Long userId) {
+        List<Long> productIds = products.stream().map(Product::getId).toList();
 
         Map<Long, ProductCategory> categoryByProductId = productTagRepository
-                .findProductTypeByProductIds(productIds, TagType.PRODUCT_TYPE)
-                .stream()
-                .collect(Collectors.toMap(
-                        ProductTagRepository.ProductTypeRow::getProductId,
-                        row -> ProductCategory.valueOf(row.getCategoryName())
-                ));
+            .findProductTypeByProductIds(productIds, TagType.PRODUCT_TYPE)
+            .stream()
+            .collect(Collectors.toMap(
+                ProductTagRepository.ProductTypeRow::getProductId,
+                row -> ProductCategory.valueOf(row.getCategoryName())
+            ));
 
         Set<Long> likedProductIds = (userId != null && !productIds.isEmpty())
                 ? userLikeProductRepository.findLikedProductIds(userId, productIds)
@@ -190,13 +276,16 @@ public class ProductService {
                 ? userScrapProductRepository.findScrappedProductIds(userId, productIds)
                 : new HashSet<>();
 
-        // 5. 변환 (Mapper 위임)
-        return page.map(p -> productMapper.toListItemResponse(
+        List<ProductListItemResponse> content = products.stream()
+            .map(p -> productMapper.toListItemResponse(
                 p,
                 categoryByProductId.get(p.getId()),
                 likedProductIds.contains(p.getId()),
                 scrappedProductIds.contains(p.getId())
-        ));
+            ))
+            .toList();
+
+        return new org.springframework.data.domain.PageImpl<>(content, pageable, total);
     }
 
     // 상품 수정

--- a/src/main/java/com/roome/roome/be/domain/reference/dto/response/CommonReferenceInfo.java
+++ b/src/main/java/com/roome/roome/be/domain/reference/dto/response/CommonReferenceInfo.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 public record CommonReferenceInfo(
         Long referenceId,
+		String name,
         String nickname,
         Long userId,
         List<String> imageUrlList,

--- a/src/main/java/com/roome/roome/be/domain/reference/mapper/ReferenceMapper.java
+++ b/src/main/java/com/roome/roome/be/domain/reference/mapper/ReferenceMapper.java
@@ -30,6 +30,7 @@ public class ReferenceMapper {
 
         return new CommonReferenceInfo(
                 reference.getId(),
+                reference.getName(),
                 reference.getUser().getNickname(),
                 reference.getUser().getId(),
                 imageUrlList,

--- a/src/main/java/com/roome/roome/be/domain/reference/repository/ReferenceCustomRepository.java
+++ b/src/main/java/com/roome/roome/be/domain/reference/repository/ReferenceCustomRepository.java
@@ -10,6 +10,7 @@ import com.roome.roome.be.domain.user.enums.MoodType;
 import com.roome.roome.be.domain.user.enums.SpaceType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 
 import java.util.List;
 import java.util.Set;
@@ -38,4 +39,31 @@ public interface ReferenceCustomRepository {
     }
 
     List<CommonReferenceInfo> findUserUploadedReferenceListByUserId(Long userId);
+
+    Page<Reference> findBaseList(String keyWord, Pageable pageable);
+
+    long countBase(String keyWord);
+
+    // 추천 count
+    long countRecommendedWithKeyword(String keyWord, List<MoodType> moodTypes, List<SpaceType> spaceTypes);
+
+    // 추천
+    List<Reference> findRecommendedSliceWithKeyword(
+        String keyWord,
+        List<MoodType> moodTypes,
+        List<SpaceType> spaceTypes,
+        long offset,
+        int limit,
+        Sort sort
+    );
+
+    // 비추천 slice (keyWord 포함, NOT 추천)
+    List<Reference> findNonRecommendedSliceWithKeyword(
+        String keyWord,
+        List<MoodType> moodTypes,
+        List<SpaceType> spaceTypes,
+        long offset,
+        int limit,
+        Sort sort
+    );
 }

--- a/src/main/java/com/roome/roome/be/domain/reference/repository/ReferenceCustomRepositoryImpl.java
+++ b/src/main/java/com/roome/roome/be/domain/reference/repository/ReferenceCustomRepositoryImpl.java
@@ -8,6 +8,7 @@ import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.roome.roome.be.domain.product.enums.TagType;
@@ -38,7 +39,6 @@ import static com.roome.roome.be.domain.reference.entity.QReference.reference;
 import static com.roome.roome.be.domain.reference.entity.QReferenceImage.referenceImage;
 import static com.roome.roome.be.domain.reference.entity.QReferenceTag.referenceTag;
 import static com.roome.roome.be.domain.user.entity.QUser.user;
-import static com.roome.roome.be.domain.user.entity.QUserScrapReference.userScrapReference;
 
 @RequiredArgsConstructor
 @Repository
@@ -97,8 +97,8 @@ public class ReferenceCustomRepositoryImpl implements ReferenceCustomRepository 
             for (Sort.Order order : pageable.getSort()) {
                 Order direction = order.getDirection().isAscending() ? Order.ASC : Order.DESC;
                 switch (order.getProperty()) {
-                    case "scrapCount":
-                        orders.add(new OrderSpecifier<>(direction, reference.scrapCount));
+                    case "likeCount":
+                        orders.add(new OrderSpecifier<>(direction, reference.likeCount));
                         break;
                     case "createdAt":
                         orders.add(new OrderSpecifier<>(direction, reference.createdAt));
@@ -112,10 +112,200 @@ public class ReferenceCustomRepositoryImpl implements ReferenceCustomRepository 
                 }
             }
         } else {
-            orders.add(new OrderSpecifier<>(Order.DESC, reference.scrapCount));
+            orders.add(new OrderSpecifier<>(Order.DESC, reference.likeCount));
         }
 
         return orders.toArray(new OrderSpecifier[0]);
+    }
+
+
+    @Override
+    public Page<Reference> findBaseList(String keyWord, Pageable pageable) {
+        BooleanExpression keywordCond = nameContains(keyWord);
+
+        JPAQuery<Reference> query = jpaQueryFactory
+            .selectFrom(reference)
+            .leftJoin(reference.user, user).fetchJoin()
+            .where(keywordCond);
+
+        applySort(query, pageable.getSort());
+
+        query.offset(pageable.getOffset()).limit(pageable.getPageSize());
+
+        List<Reference> content = query.fetch();
+
+        JPAQuery<Long> countQuery = jpaQueryFactory
+            .select(reference.count())
+            .from(reference)
+            .where(keywordCond);
+
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+    }
+
+    @Override
+    public long countBase(String keyWord) {
+        Long cnt = jpaQueryFactory
+            .select(reference.count())
+            .from(reference)
+            .where(nameContains(keyWord))
+            .fetchOne();
+        return (cnt == null) ? 0L : cnt;
+    }
+
+    @Override
+    public long countRecommendedWithKeyword(String keyWord, List<MoodType> moodTypes, List<SpaceType> spaceTypes) {
+        BooleanExpression keywordCond = nameContains(keyWord);
+        BooleanExpression recCond = recommendedCondition(moodTypes, spaceTypes);
+
+        Long cnt = jpaQueryFactory
+            .select(reference.count())
+            .from(reference)
+            .where(keywordCond, recCond)
+            .fetchOne();
+
+        return (cnt == null) ? 0L : cnt;
+    }
+
+    @Override
+    public List<Reference> findRecommendedSliceWithKeyword(
+        String keyWord,
+        List<MoodType> moodTypes,
+        List<SpaceType> spaceTypes,
+        long offset,
+        int limit,
+        Sort sort
+    ) {
+        if (limit <= 0) return List.of();
+
+        BooleanExpression keywordCond = nameContains(keyWord);
+        BooleanExpression recCond = recommendedCondition(moodTypes, spaceTypes);
+
+        JPAQuery<Reference> query = jpaQueryFactory
+            .selectFrom(reference)
+            .leftJoin(reference.user, user).fetchJoin()
+            .where(keywordCond, recCond);
+
+        applySort(query, sort);
+
+        query.offset(offset).limit(limit);
+
+        return query.fetch();
+    }
+
+    @Override
+    public List<Reference> findNonRecommendedSliceWithKeyword(
+        String keyWord,
+        List<MoodType> moodTypes,
+        List<SpaceType> spaceTypes,
+        long offset,
+        int limit,
+        Sort sort
+    ) {
+        if (limit <= 0) return List.of();
+
+        BooleanExpression keywordCond = nameContains(keyWord);
+        BooleanExpression recCond = recommendedCondition(moodTypes, spaceTypes);
+
+        // 추천 제외: NOT(recommendedCondition)
+        BooleanExpression nonRecCond = (recCond == null) ? null : recCond.not();
+
+        JPAQuery<Reference> query = jpaQueryFactory
+            .selectFrom(reference)
+            .leftJoin(reference.user, user).fetchJoin()
+            .where(keywordCond, nonRecCond);
+
+        applySort(query, sort);
+
+        query.offset(offset).limit(limit);
+
+        return query.fetch();
+    }
+
+
+    // 추천 조건을 EXISTS로 구성
+    private BooleanExpression recommendedCondition(List<MoodType> moodTypes, List<SpaceType> spaceTypes) {
+        BooleanExpression moodCond = existsMoodType(moodTypes);
+        BooleanExpression spaceCond = existsSpaceType(spaceTypes);
+
+        if (moodCond != null && spaceCond != null) return moodCond.or(spaceCond);
+        return (moodCond != null) ? moodCond : spaceCond;
+    }
+
+    private BooleanExpression existsMoodType(List<MoodType> moodTypes) {
+        if (moodTypes == null || moodTypes.isEmpty()) return null;
+
+        List<String> names = moodTypes.stream().map(Enum::name).toList();
+
+        return JPAExpressions
+            .selectOne()
+            .from(referenceTag)
+            .join(referenceTag.tag, tag)
+            .where(
+                referenceTag.reference.eq(reference),
+                tag.type.eq(TagType.REFERENCE_MOOD),
+                tag.name.in(names)
+            )
+            .exists();
+    }
+
+    private BooleanExpression existsSpaceType(List<SpaceType> spaceTypes) {
+        if (spaceTypes == null || spaceTypes.isEmpty()) return null;
+
+        List<String> names = spaceTypes.stream().map(Enum::name).toList();
+
+        return JPAExpressions
+            .selectOne()
+            .from(referenceTag)
+            .join(referenceTag.tag, tag)
+            .where(
+                referenceTag.reference.eq(reference),
+                tag.type.eq(TagType.REFERENCE_TYPE),
+                tag.name.in(names)
+            )
+            .exists();
+    }
+
+    private BooleanExpression nameContains(String keyWord) {
+        return (keyWord != null && !keyWord.isBlank())
+            ? reference.name.containsIgnoreCase(keyWord)
+            : null;
+    }
+
+    //정렬
+    private void applySort(JPAQuery<Reference> query, Sort sort) {
+        if (sort == null || sort.isUnsorted()) {
+            query.orderBy(reference.likeCount.desc(), reference.id.desc());
+            return;
+        }
+
+        List<OrderSpecifier<?>> orders = new ArrayList<>();
+
+        for (Sort.Order o : sort) {
+            String prop = o.getProperty();
+            Order dir = o.isAscending() ? Order.ASC : Order.DESC;
+
+            OrderSpecifier<?> spec = switch (prop) {
+                case "likeCount" -> new OrderSpecifier<>(dir, reference.likeCount);
+                case "createdAt" -> new OrderSpecifier<>(dir, reference.createdAt);
+                case "id" -> new OrderSpecifier<>(dir, reference.id);
+                default -> null;
+            };
+
+            if (spec != null) orders.add(spec);
+        }
+
+        if (orders.isEmpty()) {
+            query.orderBy(reference.likeCount.desc(), reference.id.desc());
+            return;
+        }
+
+        // 동점 tie-breaker가 없으면 id desc 붙여주기
+        boolean hasId = sort.stream().anyMatch(o -> "id".equals(o.getProperty()));
+        if (!hasId) {
+            orders.add(reference.id.desc());
+        }
+
+        query.orderBy(orders.toArray(new OrderSpecifier[0]));
     }
 
     @Override

--- a/src/main/java/com/roome/roome/be/domain/reference/service/ReferenceService.java
+++ b/src/main/java/com/roome/roome/be/domain/reference/service/ReferenceService.java
@@ -259,6 +259,7 @@ public class ReferenceService {
         List<CommonReferenceInfo> finalList = rawList.stream()
                 .map(raw -> new CommonReferenceInfo(
                         raw.referenceId(),
+                        raw.name(),
                         raw.nickname(),
                         raw.userId(),
                         raw.imageUrlList().stream()

--- a/src/main/java/com/roome/roome/be/domain/reference/service/ReferenceService.java
+++ b/src/main/java/com/roome/roome/be/domain/reference/service/ReferenceService.java
@@ -17,6 +17,7 @@ import com.roome.roome.be.domain.user.repository.UserScrapReferenceRepository;
 import jakarta.transaction.Transactional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -71,28 +72,107 @@ public class ReferenceService {
     @Transactional
     public Page<CommonReferenceInfo> getReferenceList(Long userId, String keyWord, Pageable pageable) {
 
-        // 1. 조회 대상 결정 (검색 vs 추천)
-        Page<Reference> referencePage;
-        if (keyWord != null && !keyWord.isBlank()) {
-            referencePage = referenceRepository.findByNameContaining(keyWord, pageable);
-        } else {
-            referencePage = getRecommendedReferences(userId, pageable);
-        }
+        // keyWord 있으면 검색만
+        Sort bucketSort = Sort.by(Sort.Direction.DESC, "likeCount")
+            .and(Sort.by(Sort.Direction.DESC, "id"));
 
-        if (referencePage.isEmpty()) {
-            return Page.empty(pageable);
-        }
-
-        // 2. 좋아요/스크랩 정보 조회
-        List<Long> referenceIds = referencePage.getContent().stream().map(Reference::getId).toList();
-        Set<Long> scrappedIds = (userId != null) ? userScrapReferenceRepository.findScrappedReferenceIds(userId, referenceIds) : new HashSet<>();
-        Set<Long> likedIds = (userId != null) ? userLikeReferenceRepository.findLikedReferenceIds(userId, referenceIds) : new HashSet<>();
-
-        // 3. 변환
-        return referencePage.map(ref ->
-                referenceMapper.toCommonInfo(ref, scrappedIds.contains(ref.getId()), likedIds.contains(ref.getId()))
+        Pageable bucketPageable = org.springframework.data.domain.PageRequest.of(
+            pageable.getPageNumber(),
+            pageable.getPageSize(),
+            bucketSort
         );
+
+        if (keyWord != null && !keyWord.isBlank()) {
+            Page<Reference> page = referenceCustomRepository.findBaseList(keyWord, bucketPageable);
+            if (page.isEmpty()) return Page.empty(bucketPageable);
+            return mapToCommonInfo(page, userId);
+        }
+
+        // keyWord 없을 때만: 추천 + 비추천 섞기
+        int pageSize = bucketPageable.getPageSize();
+        long offset = bucketPageable.getOffset();
+
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+        UserOnboarding onboarding = userOnboardingRepository.findByUser(user).orElse(null);
+
+        List<MoodType> moodTypes = (onboarding != null && onboarding.getMoodType() != null)
+            ? List.of(onboarding.getMoodType()) : List.of();
+
+        List<SpaceType> spaceTypes = (onboarding != null && onboarding.getSpaceType() != null)
+            ? List.of(onboarding.getSpaceType()) : List.of();
+
+        // 온보딩 없으면 전체
+        if (moodTypes.isEmpty() && spaceTypes.isEmpty()) {
+            Page<Reference> page = referenceCustomRepository.findBaseList(null, bucketPageable);
+            if (page.isEmpty()) return Page.empty(bucketPageable);
+            return mapToCommonInfo(page, userId);
+        }
+
+        // 전체 갯수
+        long totalAll = referenceCustomRepository.countBase(null);
+
+        // 추천 갯수
+        long recTotal = referenceCustomRepository.countRecommendedWithKeyword(null, moodTypes, spaceTypes);
+
+
+        long recStart = offset;
+        int recLimit = (recStart < recTotal)
+            ? (int) Math.min(pageSize, recTotal - recStart)
+            : 0;
+
+        List<Reference> recommended = (recLimit > 0)
+            ? referenceCustomRepository.findRecommendedSliceWithKeyword(
+            null, moodTypes, spaceTypes, recStart, recLimit, bucketSort
+        )
+            : List.of();
+
+        int remain = pageSize - recommended.size();
+        if (remain <= 0) {
+            return mapToCommonInfo(new org.springframework.data.domain.PageImpl<>(recommended, bucketPageable, totalAll), userId);
+        }
+
+        long nonRecOffset = Math.max(0, offset - recTotal);
+
+        List<Reference> nonRecommended =
+            referenceCustomRepository.findNonRecommendedSliceWithKeyword(
+                null, moodTypes, spaceTypes, nonRecOffset, remain, bucketSort
+            );
+
+        List<Reference> mixed = new ArrayList<>(pageSize);
+        mixed.addAll(recommended);
+        mixed.addAll(nonRecommended);
+
+        if (mixed.isEmpty()) return Page.empty(bucketPageable);
+        return mapToCommonInfo(mixed, bucketPageable, totalAll, userId);
     }
+
+    private Page<CommonReferenceInfo> mapToCommonInfo(Page<Reference> page, Long userId) {
+        return mapToCommonInfo(page.getContent(), page.getPageable(), page.getTotalElements(), userId);
+    }
+
+    private Page<CommonReferenceInfo> mapToCommonInfo(List<Reference> references, Pageable pageable, long total, Long userId) {
+        List<Long> referenceIds = references.stream().map(Reference::getId).toList();
+
+        Set<Long> scrappedIds = (userId != null && !referenceIds.isEmpty())
+            ? userScrapReferenceRepository.findScrappedReferenceIds(userId, referenceIds)
+            : new HashSet<>();
+
+        Set<Long> likedIds = (userId != null && !referenceIds.isEmpty())
+            ? userLikeReferenceRepository.findLikedReferenceIds(userId, referenceIds)
+            : new HashSet<>();
+
+        List<CommonReferenceInfo> content = references.stream()
+            .map(ref -> referenceMapper.toCommonInfo(
+                ref,
+                scrappedIds.contains(ref.getId()),
+                likedIds.contains(ref.getId())
+            ))
+            .toList();
+
+        return new org.springframework.data.domain.PageImpl<>(content, pageable, total);
+    }
+
 
     private Page<Reference> getRecommendedReferences(Long userId, Pageable pageable) {
         if (userId == null) return referenceRepository.findAll(pageable); // 비로그인 대비(혹은 예외)

--- a/src/main/java/com/roome/roome/be/domain/user/service/UserLikeService.java
+++ b/src/main/java/com/roome/roome/be/domain/user/service/UserLikeService.java
@@ -151,6 +151,7 @@ public class UserLikeService {
         List<CommonReferenceInfo> finalList = rawList.stream()
                 .map(raw -> new CommonReferenceInfo(
                         raw.referenceId(),
+                        raw.name(),
                         raw.nickname(),
                         raw.userId(),
                         raw.imageUrlList().stream()

--- a/src/main/java/com/roome/roome/be/domain/user/service/UserScrapService.java
+++ b/src/main/java/com/roome/roome/be/domain/user/service/UserScrapService.java
@@ -147,6 +147,7 @@ public class UserScrapService {
         List<CommonReferenceInfo> finalList = rawList.stream()
                 .map(raw -> new CommonReferenceInfo(
                         raw.referenceId(),
+                        raw.name(),
                         raw.nickname(),
                         raw.userId(),
                         raw.imageUrlList().stream()


### PR DESCRIPTION
## #️⃣ 관련 이슈
closed #108

## 💡 작업 배경
상품, 레퍼런스 전체 조회시 온보딩 매칭 결과 없는 사용자의 경우 빈값 나오는 문제가 발생하고 있다.

## 🧩 작업 내용
### 상품
- 상품의 경우, 온보딩 매칭 결과가 없을시에는 전체 상품을 최신순으로 보여주도록 기본 설정
- 온보딩 매칭이 되는 경우지만 필터를 적용하지 않은 경우, 매칭된 상품을 보여준다음 이어서 비매칭된 상품 보여주도록 수정
- 온보딩 매칭이 되는 경우지만 필터 적용한 경우, 추천+비추천 조합이 아닌, 필터 적용된 상품만 보이도록 수정
### 레퍼런스
- 레퍼런스의 경우 온보딩 매칭 결과가 없을시 인기순으로 보여주도록 수정
- 온보딩 매칭이 되는 경우, 매칭된 추천 레퍼런스 내에서 인기순으로 구성하고, 추천 레퍼런스 뒤에 비매칭된 레퍼런스들끼리의 인기순으로 구성
- 검색시에는 검색에만 적용된 레퍼런스 보여주도록 수정
- 리스트 조회시 레퍼런스 제목도 응답하도록 수정

## 📸 스크린샷(선택)
현재 문제점
<img width="1170" height="635" alt="Screenshot 2026-01-10 at 7 10 43 PM" src="https://github.com/user-attachments/assets/9c6ba3ba-c61e-4741-a3d0-f2f4353524e5" />
-> 다음와 같이 온보딩 매칭이 안된 사용자의 경우는 빈값으로 나온다
-> 이 부분을 해결하여 아래와 같이 결과가 나오도록 수정하였다.
<img width="1115" height="522" alt="Screenshot 2026-01-10 at 7 11 24 PM" src="https://github.com/user-attachments/assets/39d2513a-97e3-4f4f-ad8a-7b729e6efc68" />

## 📝 기타
레퍼런스가 스크랩을 기준으로 나오도록 되어있는데 인기순 정렬은 좋아요로 하기로 했던것 같아서 좋아요 순으로 일단 수정했습니다!
이 부분 관련해서 회의록을 참고하려고 했는데 회의록에 적힌 부분이 없어 일단 이렇게 수정했습니다.