### PR TITLE
[Fix] 레퍼런스 좋아요, 스크랩 조회 오류

### DIFF
--- a/src/main/java/com/roome/roome/be/domain/reference/repository/ReferenceCustomRepositoryImpl.java
+++ b/src/main/java/com/roome/roome/be/domain/reference/repository/ReferenceCustomRepositoryImpl.java
@@ -347,6 +347,7 @@ public class ReferenceCustomRepositoryImpl implements ReferenceCustomRepository 
                                 Projections.constructor(
                                         CandidateReferenceInfo.class,
                                         reference.id,
+                                        user.nickname,
                                         referenceImage.imageUrl.min(),
                                         reference.description,
                                         GroupBy.set(
@@ -461,6 +462,7 @@ public class ReferenceCustomRepositoryImpl implements ReferenceCustomRepository 
                         groupBy(reference.id).list(
                                 Projections.constructor(CommonReferenceInfo.class,
                                         reference.id,
+                                        reference.name,
                                         reference.user.nickname,
                                         reference.user.id,
                                         GroupBy.list(referenceImage.objectKey),

--- a/src/main/java/com/roome/roome/be/domain/user/repository/UserLikeReferenceCustomRepositoryImpl.java
+++ b/src/main/java/com/roome/roome/be/domain/user/repository/UserLikeReferenceCustomRepositoryImpl.java
@@ -39,6 +39,7 @@ public class UserLikeReferenceCustomRepositoryImpl implements UserLikeReferenceC
                     Projections.constructor(
                         CommonReferenceInfo.class,
                         reference.id,
+                        reference.name,
                         user.nickname,
                         user.id,
                         list(referenceImage.imageUrl),

--- a/src/main/java/com/roome/roome/be/domain/user/repository/UserScrapReferenceCustomRepositoryImpl.java
+++ b/src/main/java/com/roome/roome/be/domain/user/repository/UserScrapReferenceCustomRepositoryImpl.java
@@ -33,6 +33,7 @@ public class UserScrapReferenceCustomRepositoryImpl implements UserScrapReferenc
                         groupBy(reference.id).list(
                                 Projections.constructor(CommonReferenceInfo.class,
                                         reference.id,
+                                        reference.name,
                                         reference.user.nickname,
                                         reference.user.id,
                                         GroupBy.list(referenceImage.objectKey),


### PR DESCRIPTION
## #️⃣ 관련 이슈
closed #110

## 💡 작업 배경
레퍼런스 좋아요, 스크랩 조회 오류가 나고 있다.

## 🧩 작업 내용
CommonReferenceInfo 응답에 레퍼런스 제목을 추가하면서 QueryDSL 응답 생성시 생성자 파라미터 수 불일치로 생기는 문제 해결

## 📸 스크린샷(선택)
<img width="1200" height="553" alt="Screenshot 2026-01-10 at 11 09 06 PM" src="https://github.com/user-attachments/assets/789b3976-7802-4dab-99a5-b384b30ab780" />

## 📝 기타
