### PR TITLE
[Fix] QueryDSL DTO 매핑 오류 수정

### DIFF
--- a/src/main/java/com/roome/roome/be/domain/reference/repository/ReferenceCustomRepositoryImpl.java
+++ b/src/main/java/com/roome/roome/be/domain/reference/repository/ReferenceCustomRepositoryImpl.java
@@ -347,7 +347,6 @@ public class ReferenceCustomRepositoryImpl implements ReferenceCustomRepository 
                                 Projections.constructor(
                                         CandidateReferenceInfo.class,
                                         reference.id,
-                                        user.nickname,
                                         referenceImage.imageUrl.min(),
                                         reference.description,
                                         GroupBy.set(


### PR DESCRIPTION
## #️⃣ 관련 이슈
closed #112 

## 💡 작업 배경
QueryDSL DTO 매핑 중 추천 레퍼런스 후보 관련 Dto 매핑 갯수 오류가 나고 있었다.

## 🧩 작업 내용
QueryDSL DTO 매핑 오류 수정

## 📸 스크린샷(선택)
<img width="1160" height="509" alt="Screenshot 2026-01-11 at 11 50 51 PM" src="https://github.com/user-attachments/assets/a9bc2ed9-2b68-4070-8335-096cdbe4512c" />


## 📝 기타
