### PR TITLE
[Feat] 챗봇 추천 결과 저장/조회를 위한 API

### DIFF
--- a/src/main/java/com/roome/roome/be/common/status/ErrorStatus.java
+++ b/src/main/java/com/roome/roome/be/common/status/ErrorStatus.java
@@ -120,7 +120,7 @@ public enum ErrorStatus implements BaseStatus {
      * Board
      */
     SESSION_NOT_FOUND("SESSION_404", HttpStatus.NOT_FOUND, "유효하지 않은 세션입니다."),
-    SESSION_USER_MISMATCH("SESSION_403", HttpStatus.FORBIDDEN, "본인의 세션 결과만 저장할 수 있습니다."),
+    SESSION_USER_MISMATCH("SESSION_404", HttpStatus.FORBIDDEN, "본인의 세션 결과만 저장할 수 있습니다."),
     RESULT_NOT_FOUND("SESSION_404", HttpStatus.NOT_FOUND, "저장할 추천 결과가 없습니다.");
 
     private final String code;

--- a/src/main/java/com/roome/roome/be/common/status/ErrorStatus.java
+++ b/src/main/java/com/roome/roome/be/common/status/ErrorStatus.java
@@ -1,6 +1,8 @@
 package com.roome.roome.be.common.status;
 
 import com.roome.roome.be.common.base.BaseStatus;
+import com.roome.roome.be.domain.chat.enums.ChatMode;
+import com.roome.roome.be.domain.chat.model.ChatSession;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
@@ -112,7 +114,14 @@ public enum ErrorStatus implements BaseStatus {
     COMMENT_NOT_FOUND("COMMENT_404", HttpStatus.NOT_FOUND, "존재하지 않는 댓글입니다."),
     COMMENTABLE_ENTITY_NOT_FOUND("COMMENT_404", HttpStatus.NOT_FOUND, "댓글을 달 대상(게시글/상품 등)이 존재하지 않습니다."),
     COMMENT_AUTHOR_MISMATCH("COMMENT_403", HttpStatus.FORBIDDEN, "댓글 수정/삭제 권한이 없습니다."),
-    COMMENT_CONTENT_TOO_LONG("COMMENT_400", HttpStatus.BAD_REQUEST, "댓글 내용은 최대 400자까지 입력 가능합니다.");
+    COMMENT_CONTENT_TOO_LONG("COMMENT_400", HttpStatus.BAD_REQUEST, "댓글 내용은 최대 400자까지 입력 가능합니다."),
+
+    /**
+     * Board
+     */
+    SESSION_NOT_FOUND("SESSION_404", HttpStatus.NOT_FOUND, "유효하지 않은 세션입니다."),
+    SESSION_USER_MISMATCH("SESSION_403", HttpStatus.FORBIDDEN, "본인의 세션 결과만 저장할 수 있습니다."),
+    RESULT_NOT_FOUND("SESSION_404", HttpStatus.NOT_FOUND, "저장할 추천 결과가 없습니다.");
 
     private final String code;
     private final HttpStatus httpStatus;

--- a/src/main/java/com/roome/roome/be/common/status/SuccessStatus.java
+++ b/src/main/java/com/roome/roome/be/common/status/SuccessStatus.java
@@ -34,7 +34,7 @@ public enum SuccessStatus implements BaseStatus {
     /**
      * Inquiry
      */
-    GET_INQUIRY_LIST_SUCCESS("INQUIRY_200",HttpStatus.OK,"문의하기 전체 내역 조회 성공"),
+    GET_INQUIRY_LIST_SUCCESS("INQUIRY_200", HttpStatus.OK, "문의하기 전체 내역 조회 성공"),
     UPDATE_INQUIRY_ANSWER_SUCCESS("INQUIRY_200", HttpStatus.CREATED, "문의 답변 수정 성공"),
     REGISTER_INQUIRY_SUCCESS("INQUIRY_201", HttpStatus.CREATED, "문의 등록 성공"),
     REGISTER_INQUIRY_ANSWER_SUCCESS("INQUIRY_201", HttpStatus.CREATED, "문의 답변 등록 성공"),
@@ -45,13 +45,13 @@ public enum SuccessStatus implements BaseStatus {
      */
     SAVE_USER_ONBOARDING_SUCCESS("AUTH_201", HttpStatus.CREATED, "유저 온보딩 저장 성공"),
     CHECK_USER_ONBOARDING_EXISTENCE_SUCCESS("AUTH_200", HttpStatus.OK, "유저 온보딩 존재 여부 조회 성공"),
-    GET_USER_LIKE_PRODUCT_LIST_SUCCESS("USER_200",HttpStatus.OK, "유저 좋아요 상품 리스트 조회 성공"),
-    GET_USER_LIKE_REFERENCE_LIST_SUCCESS("PRODUCT_200",HttpStatus.OK,"유저 좋아요 레퍼런스 리스트 조회 성공" ),
-    GET_USER_SCRAP_PRODUCT_LIST_SUCCESS("USER_200",HttpStatus.OK, "유저 스크랩 상품 리스트 조회 성공"),
-    GET_USER_SCRAP_REFERENCE_LIST_SUCCESS("USER_200",HttpStatus.OK, "유저 스크랩 레퍼런스 리스트 조회 성공"),
-    GET_USER_PROFILE_SUCCESS("USER_200",HttpStatus.OK,"유저 프로필 조회 성공"),
-    UPDATE_USER_PROFILE_SUCCESS("USER_200",HttpStatus.OK,"유저 프로필 수정 성공"),
-    GET_USER_REFERENCE_SUCCESS("USER_200",HttpStatus.OK,"유저 업로드 레퍼런스 리스트 조회 성공"),
+    GET_USER_LIKE_PRODUCT_LIST_SUCCESS("USER_200", HttpStatus.OK, "유저 좋아요 상품 리스트 조회 성공"),
+    GET_USER_LIKE_REFERENCE_LIST_SUCCESS("PRODUCT_200", HttpStatus.OK, "유저 좋아요 레퍼런스 리스트 조회 성공"),
+    GET_USER_SCRAP_PRODUCT_LIST_SUCCESS("USER_200", HttpStatus.OK, "유저 스크랩 상품 리스트 조회 성공"),
+    GET_USER_SCRAP_REFERENCE_LIST_SUCCESS("USER_200", HttpStatus.OK, "유저 스크랩 레퍼런스 리스트 조회 성공"),
+    GET_USER_PROFILE_SUCCESS("USER_200", HttpStatus.OK, "유저 프로필 조회 성공"),
+    UPDATE_USER_PROFILE_SUCCESS("USER_200", HttpStatus.OK, "유저 프로필 수정 성공"),
+    GET_USER_REFERENCE_SUCCESS("USER_200", HttpStatus.OK, "유저 업로드 레퍼런스 리스트 조회 성공"),
 
     /**
      * Shop
@@ -59,14 +59,14 @@ public enum SuccessStatus implements BaseStatus {
     REGISTER_SHOP_SUCCESS("SHOP_201", HttpStatus.CREATED, "가게 등록 성공"),
     UPDATE_SHOP_SUCCESS("SHOP_200", HttpStatus.OK, "가게 수정 성공"),
     DELETE_SHOP_SUCCESS("SHOP_200", HttpStatus.OK, "가게 삭제 성공"),
-    GET_SHOP_DETAIL_SUCCESS("SHOP_200",HttpStatus.OK ,"가게 상세 조회 성공" ),
-    GET_SHOP_LIST_SUCCESS("SHOP_200",HttpStatus.OK ,"가게 목록 조회 성공" ),
+    GET_SHOP_DETAIL_SUCCESS("SHOP_200", HttpStatus.OK, "가게 상세 조회 성공"),
+    GET_SHOP_LIST_SUCCESS("SHOP_200", HttpStatus.OK, "가게 목록 조회 성공"),
 
     /**
      * S3
      */
     S3_PRESIGNED_ISSUE_SUCCESS("S3_200", HttpStatus.OK, "Presigned URL 발급 성공"),
-    S3_COMMIT_SUCCESS("S3_200",HttpStatus.OK,"S3 이미지 업로드 성공"),
+    S3_COMMIT_SUCCESS("S3_200", HttpStatus.OK, "S3 이미지 업로드 성공"),
 
     /**
      * Product
@@ -76,18 +76,18 @@ public enum SuccessStatus implements BaseStatus {
     CREATE_PRODUCT_SCRAP("PRODUCT_200", HttpStatus.OK, "상품 스크랩 토글 성공"),
     GET_PRODUCT_DETAIL("PRODUCT_200", HttpStatus.OK, "상품 상세 조회 성공"),
     GET_PRODUCT_LIST("PRODUCT_200", HttpStatus.OK, "상품 목록 조회 성공"),
-    UPDATE_PRODUCT_SUCCESS("PRODUCT_200", HttpStatus.OK,"상품 수정 성공"),
-    UPDATE_PRODUCT_IMAGES_SUCCESS("PRODUCT_200", HttpStatus.OK,"상품 이미지 수정 성공"),
+    UPDATE_PRODUCT_SUCCESS("PRODUCT_200", HttpStatus.OK, "상품 수정 성공"),
+    UPDATE_PRODUCT_IMAGES_SUCCESS("PRODUCT_200", HttpStatus.OK, "상품 이미지 수정 성공"),
     DELETE_PRODUCT_SUCCESS("PRODUCT_200", HttpStatus.OK, "상품 삭제 성공"),
 
     /**
      * Reference
      */
-    REGISTER_REFERENCE_SUCCESS("REFERENCE_201", HttpStatus.CREATED,"레퍼런스 등록 성공"),
-    REGISTER_REFERENCE_IMAGE_SUCCESS("REFERENCE_201", HttpStatus.CREATED,"레퍼런스 이미지 등록 성공"),
+    REGISTER_REFERENCE_SUCCESS("REFERENCE_201", HttpStatus.CREATED, "레퍼런스 등록 성공"),
+    REGISTER_REFERENCE_IMAGE_SUCCESS("REFERENCE_201", HttpStatus.CREATED, "레퍼런스 이미지 등록 성공"),
     CREATE_REFERENCE_SCRAP("REFERENCE_200", HttpStatus.OK, "레퍼런스 스크랩 토글 성공"),
-    GET_REFERENCE_LIST_SUCCESS("REFERENCE_200",HttpStatus.OK,"레퍼런스 리스트 조회 성공"),
-    CREATE_REFERENCE_LIKE("REFERENCE_200",HttpStatus.OK,"레퍼런스 좋아요 토글 성공" ),
+    GET_REFERENCE_LIST_SUCCESS("REFERENCE_200", HttpStatus.OK, "레퍼런스 리스트 조회 성공"),
+    CREATE_REFERENCE_LIKE("REFERENCE_200", HttpStatus.OK, "레퍼런스 좋아요 토글 성공"),
     GET_RELATED_REFERENCES_SUCCESS("REFERENCE_200", HttpStatus.OK, "연관 레퍼런스 조회에 성공했습니다."),
     GET_REFERENCE_DETAIL_SUCCESS("REFERENCE_200", HttpStatus.OK, "레퍼런스 상세 조회에 성공했습니다."),
 
@@ -103,18 +103,23 @@ public enum SuccessStatus implements BaseStatus {
     /**
      * Search
      */
-    GET_POPULAR_KEYWORDS_LIST_SUCCESS("SEARCH_200",HttpStatus.OK, "인기 검색어 조회 성공"),
-    RECORD_SEARCH_KEYWORD_SUCCESS( "SEARCH_201", HttpStatus.OK,"검색어 기록 성공"),
-    GET_RECENT_KEYWORDS_LIST_SUCCESS("SEARCH_200",HttpStatus.OK, "최근 검색어 조회 성공"),
-    DELETE_RECENT_KEYWORD_SUCCESS("SEARCH_200", HttpStatus.OK,"최근 검색어 개별 삭제 성공" ),
-    DELETE_ALL_RECENT_KEYWORDS_SUCCESS("SEARCH_200", HttpStatus.OK,"최근 검색어 전체 삭제 성공" ),
+    GET_POPULAR_KEYWORDS_LIST_SUCCESS("SEARCH_200", HttpStatus.OK, "인기 검색어 조회 성공"),
+    RECORD_SEARCH_KEYWORD_SUCCESS("SEARCH_201", HttpStatus.OK, "검색어 기록 성공"),
+    GET_RECENT_KEYWORDS_LIST_SUCCESS("SEARCH_200", HttpStatus.OK, "최근 검색어 조회 성공"),
+    DELETE_RECENT_KEYWORD_SUCCESS("SEARCH_200", HttpStatus.OK, "최근 검색어 개별 삭제 성공"),
+    DELETE_ALL_RECENT_KEYWORDS_SUCCESS("SEARCH_200", HttpStatus.OK, "최근 검색어 전체 삭제 성공"),
 
 
     /**
      * Chat
      */
-    CHAT_SCENARIO_SUCCESS("CHAT_200", HttpStatus.OK, "채팅 시나리오 처리 성공");
+    CHAT_SCENARIO_SUCCESS("CHAT_200", HttpStatus.OK, "채팅 시나리오 처리 성공"),
 
+    /**
+     * Board
+     */
+    CREATE_BOARD_SUCCESS("BOARD_200", HttpStatus.OK, "보드 저장 처리 성공"),
+    GET_BOARD_LIST_SUCCESS("BOARD_200", HttpStatus.OK, "저장된 루미 대화 보드 리스트 조회 성공");
 
 
     private final String code;

--- a/src/main/java/com/roome/roome/be/domain/board/controller/BoardController.java
+++ b/src/main/java/com/roome/roome/be/domain/board/controller/BoardController.java
@@ -31,7 +31,7 @@ public class BoardController {
     @Operation(
             summary = "추천 결과 내 보드에 저장"
     )
-    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "응답 성공", content = @Content(schema = @Schema(implementation = ChatMessageResponse.class)))
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "응답 성공")
     public ResponseEntity<ApiResponse<Long>> saveBoard(
             @AuthenticationPrincipal Long userId,
             @RequestBody BoardSaveRequest request
@@ -45,7 +45,7 @@ public class BoardController {
     @Operation(
             summary = "루미와의 대화 추천 목록 조회"
     )
-    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "응답 성공", content = @Content(schema = @Schema(implementation = ChatMessageResponse.class)))
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "응답 성공", content = @Content(schema = @Schema(implementation = BoardListResponse.class)))
     public ResponseEntity<ApiResponse<Page<BoardListResponse>>> getBoardList(
             @AuthenticationPrincipal Long userId,
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable

--- a/src/main/java/com/roome/roome/be/domain/board/controller/BoardController.java
+++ b/src/main/java/com/roome/roome/be/domain/board/controller/BoardController.java
@@ -1,0 +1,56 @@
+package com.roome.roome.be.domain.board.controller;
+
+import com.roome.roome.be.common.response.ApiResponse;
+import com.roome.roome.be.common.status.SuccessStatus;
+import com.roome.roome.be.domain.board.dto.request.BoardSaveRequest;
+import com.roome.roome.be.domain.board.dto.response.BoardListResponse;
+import com.roome.roome.be.domain.board.service.BoardService;
+import com.roome.roome.be.domain.chat.dto.response.ChatMessageResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/boards")
+@RequiredArgsConstructor
+@Tag(name = "Boards", description = "루미와의 대화 저장(내 보드)")
+public class BoardController {
+
+    private final BoardService boardService;
+
+    @PostMapping
+    @Operation(
+            summary = "추천 결과 내 보드에 저장"
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "응답 성공", content = @Content(schema = @Schema(implementation = ChatMessageResponse.class)))
+    public ResponseEntity<ApiResponse<Long>> saveBoard(
+            @AuthenticationPrincipal Long userId,
+            @RequestBody BoardSaveRequest request
+    ) {
+        Long boardId = boardService.saveBoardFromSession(request.sessionId(), userId);
+
+        return ApiResponse.success(SuccessStatus.CREATE_BOARD_SUCCESS, boardId);
+    }
+
+    @GetMapping
+    @Operation(
+            summary = "루미와의 대화 추천 목록 조회"
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "응답 성공", content = @Content(schema = @Schema(implementation = ChatMessageResponse.class)))
+    public ResponseEntity<ApiResponse<Page<BoardListResponse>>> getBoardList(
+            @AuthenticationPrincipal Long userId,
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        Page<BoardListResponse> response = boardService.getBoardList(userId, pageable);
+        return ApiResponse.success(SuccessStatus.GET_BOARD_LIST_SUCCESS, response);
+    }
+}

--- a/src/main/java/com/roome/roome/be/domain/board/dto/request/BoardSaveRequest.java
+++ b/src/main/java/com/roome/roome/be/domain/board/dto/request/BoardSaveRequest.java
@@ -1,0 +1,7 @@
+package com.roome.roome.be.domain.board.dto.request;
+
+public record BoardSaveRequest(
+        String sessionId
+)
+{
+}

--- a/src/main/java/com/roome/roome/be/domain/board/dto/response/BoardListResponse.java
+++ b/src/main/java/com/roome/roome/be/domain/board/dto/response/BoardListResponse.java
@@ -1,0 +1,64 @@
+package com.roome.roome.be.domain.board.dto.response;
+
+import com.roome.roome.be.domain.board.entity.Board;
+import com.roome.roome.be.domain.board.entity.BoardProduct;
+import com.roome.roome.be.domain.board.entity.BoardReference;
+import com.roome.roome.be.domain.chat.enums.ChatMode;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public record BoardListResponse(
+        Long boardId,
+        Long userId,
+        String title,
+        String description,
+        List<String> keywords,
+        List<String> imageUrls,
+        List<String> productNames, // [추가] 제품명 리스트
+        ChatMode category,
+        LocalDateTime createdAt
+) {
+    public static BoardListResponse from(Board board) {
+        List<String> parsedKeywords = (board.getKeywords() != null && !board.getKeywords().isBlank())
+                ? Arrays.asList(board.getKeywords().split(", "))
+                : Collections.emptyList();
+
+        List<String> images;
+        List<String> names;
+
+        if (board.getCategory() == ChatMode.PRODUCT) {
+            images = board.getBoardProducts().stream()
+                    .map(BoardProduct::getImageUrl)
+                    .limit(4)
+                    .collect(Collectors.toList());
+
+            names = board.getBoardProducts().stream()
+                    .map(BoardProduct::getName) // Entity에 추가한 name 필드 사용
+                    .collect(Collectors.toList());
+
+        } else {
+            images = board.getBoardReferences().stream()
+                    .map(BoardReference::getImageUrl)
+                    .limit(4)
+                    .collect(Collectors.toList());
+
+            names = Collections.emptyList();
+        }
+
+        return new BoardListResponse(
+                board.getId(),
+                board.getUserId(),
+                board.getTitle(),
+                board.getDescription(),
+                parsedKeywords,
+                images,
+                names,
+                board.getCategory(),
+                board.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/roome/roome/be/domain/board/dto/response/BoardListResponse.java
+++ b/src/main/java/com/roome/roome/be/domain/board/dto/response/BoardListResponse.java
@@ -38,6 +38,7 @@ public record BoardListResponse(
 
             names = board.getBoardProducts().stream()
                     .map(BoardProduct::getName)
+                    .limit(4)
                     .collect(Collectors.toList());
 
         } else {

--- a/src/main/java/com/roome/roome/be/domain/board/dto/response/BoardListResponse.java
+++ b/src/main/java/com/roome/roome/be/domain/board/dto/response/BoardListResponse.java
@@ -37,7 +37,7 @@ public record BoardListResponse(
                     .collect(Collectors.toList());
 
             names = board.getBoardProducts().stream()
-                    .map(BoardProduct::getName) // Entity에 추가한 name 필드 사용
+                    .map(BoardProduct::getName)
                     .collect(Collectors.toList());
 
         } else {

--- a/src/main/java/com/roome/roome/be/domain/board/entity/Board.java
+++ b/src/main/java/com/roome/roome/be/domain/board/entity/Board.java
@@ -1,0 +1,56 @@
+package com.roome.roome.be.domain.board.entity;
+
+import com.roome.roome.be.common.base.BaseEntity;
+import com.roome.roome.be.domain.chat.enums.ChatMode;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "board")
+public class Board extends BaseEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "board_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ChatMode category;
+
+    @Lob
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    private String keywords;
+
+    @Builder.Default
+    @OneToMany(mappedBy = "board", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<BoardProduct> boardProducts = new ArrayList<>();
+
+    @Builder.Default
+    @OneToMany(mappedBy = "board", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<BoardReference> boardReferences = new ArrayList<>();
+
+    public void addProduct(BoardProduct product) {
+        this.boardProducts.add(product);
+        product.assignBoard(this);
+    }
+
+    public void addReference(BoardReference reference) {
+        this.boardReferences.add(reference);
+        reference.assignBoard(this);
+    }
+}

--- a/src/main/java/com/roome/roome/be/domain/board/entity/BoardProduct.java
+++ b/src/main/java/com/roome/roome/be/domain/board/entity/BoardProduct.java
@@ -1,0 +1,44 @@
+package com.roome.roome.be.domain.board.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "board_product")
+public class BoardProduct {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "board_product_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "board_id")
+    private Board board;
+
+    @Column(nullable = false)
+    private Long productId;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false, length = 2048)
+    private String imageUrl;
+
+    @Column(length = 1000)
+    private String reason;
+
+    @Column(length = 1000)
+    private String advantage;
+
+    private String mood;
+
+    private String recommendedPlace;
+
+    public void assignBoard(Board board) {
+        this.board = board;
+    }
+}

--- a/src/main/java/com/roome/roome/be/domain/board/entity/BoardReference.java
+++ b/src/main/java/com/roome/roome/be/domain/board/entity/BoardReference.java
@@ -1,0 +1,31 @@
+package com.roome.roome.be.domain.board.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "board_reference")
+public class BoardReference {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "board_reference_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "board_id")
+    private Board board;
+
+    @Column(nullable = false)
+    private Long referenceId;
+
+    @Column(nullable = false, length = 2048)
+    private String imageUrl;
+
+    public void assignBoard(Board board) {
+        this.board = board;
+    }
+}

--- a/src/main/java/com/roome/roome/be/domain/board/repository/BoardRepository.java
+++ b/src/main/java/com/roome/roome/be/domain/board/repository/BoardRepository.java
@@ -1,0 +1,15 @@
+package com.roome.roome.be.domain.board.repository;
+
+import com.roome.roome.be.domain.board.entity.Board;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface BoardRepository extends JpaRepository<Board, Long> {
+
+    List<Board> findAllByUserIdOrderByCreatedAtDesc(Long userId);
+
+    Page<Board> findAllByUserId(Long userId, Pageable pageable);
+}

--- a/src/main/java/com/roome/roome/be/domain/board/service/BoardService.java
+++ b/src/main/java/com/roome/roome/be/domain/board/service/BoardService.java
@@ -1,0 +1,175 @@
+package com.roome.roome.be.domain.board.service;
+
+import com.roome.roome.be.common.exception.GeneralException;
+import com.roome.roome.be.common.status.ErrorStatus;
+import com.roome.roome.be.domain.board.dto.response.BoardListResponse;
+import com.roome.roome.be.domain.board.entity.Board;
+import com.roome.roome.be.domain.board.entity.BoardProduct;
+import com.roome.roome.be.domain.board.entity.BoardReference;
+import com.roome.roome.be.domain.board.repository.BoardRepository;
+import com.roome.roome.be.domain.chat.dto.response.ChatProductScenarioResponse;
+import com.roome.roome.be.domain.chat.dto.response.ChatReferenceScenarioResponse;
+import com.roome.roome.be.domain.chat.dto.response.ProductSummaryResponse;
+import com.roome.roome.be.domain.chat.enums.ChatMode;
+import com.roome.roome.be.domain.chat.model.ChatSession;
+import com.roome.roome.be.domain.chat.repository.ChatSessionRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+@Slf4j
+public class BoardService {
+
+    private final ChatSessionRepository chatSessionRepository;
+    private final BoardRepository boardRepository;
+
+    public Long saveBoardFromSession(String sessionId, Long currentUserId) {
+
+        ChatSession session = chatSessionRepository.find(sessionId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.SESSION_NOT_FOUND));
+
+        if (!session.userId().equals(currentUserId)) {
+            throw new GeneralException(ErrorStatus.SESSION_USER_MISMATCH);
+        }
+
+        if (session.mode() == ChatMode.PRODUCT) {
+            return saveProductBoard(session);
+        } else if (session.mode() == ChatMode.REFERENCE) {
+            return saveReferenceBoard(session);
+        } else {
+            throw new GeneralException(ErrorStatus.RESULT_NOT_FOUND);
+        }
+    }
+
+    //  인테리어 레퍼런스 저장 로직
+    private Long saveReferenceBoard(ChatSession session) {
+        ChatReferenceScenarioResponse result = session.lastReferenceResult();
+
+        if (result == null) {
+            throw new GeneralException(ErrorStatus.RESULT_NOT_FOUND);
+        }
+
+        String title = (result.title() != null && !result.title().isBlank())
+                ? result.title()
+                : generateDefaultTitle("인테리어 무드 추천");
+
+        String fullDescription = buildDescription(result.moodDescription(), result.summary());
+
+        String keywords = (result.moodKeywords() != null)
+                ? String.join(", ", result.moodKeywords())
+                : "";
+
+        Board board = Board.builder()
+                .userId(session.userId())
+                .title(title)
+                .category(ChatMode.REFERENCE)
+                .description(fullDescription)
+                .keywords(keywords)
+                .build();
+
+        List<Long> ids = result.referenceIdList();
+        List<String> urls = result.imageUrlList();
+
+        if (ids != null && urls != null && ids.size() == urls.size()) {
+            for (int i = 0; i < ids.size(); i++) {
+                BoardReference ref = BoardReference.builder()
+                        .referenceId(ids.get(i))
+                        .imageUrl(urls.get(i))
+                        .build();
+                board.addReference(ref);
+            }
+        } else {
+            log.warn("레퍼런스 ID 목록과 이미지 URL 목록의 개수가 일치하지 않아 일부 데이터가 누락될 수 있습니다.");
+        }
+
+        return boardRepository.save(board).getId();
+    }
+
+    // 제품 추천 저장 로직
+    private Long saveProductBoard(ChatSession session) {
+        ChatProductScenarioResponse result = session.lastProductResult();
+
+        if (result == null || result.products() == null) {
+            throw new GeneralException(ErrorStatus.RESULT_NOT_FOUND);
+        }
+
+        String title = generateDefaultTitle(" 맞춤 제품 추천");
+
+        String summaryDescription = result.products().stream()
+                .findFirst()
+                .map(p -> {
+                    String productName = (p.name() != null) ? p.name() : "제품";
+                    String reason = (p.reason() != null) ? p.reason() : "추천 사유가 있습니다.";
+                    return "메인 추천: " + productName + "\n\n[AI 추천 사유]\n" + reason;
+                })
+                .orElse("고객님의 취향에 맞는 가구들을 찾아보았습니다.");
+
+        String keywords = result.products().stream()
+                .map(ProductSummaryResponse::recommendedPlace)
+                .filter(place -> place != null && !place.isBlank())
+                .flatMap(place -> Arrays.stream(place.split("/")))
+                .map(String::trim)
+                .distinct()
+                .collect(Collectors.joining(", "));
+
+        if (keywords.isBlank()) {
+            keywords = "인테리어 가구";
+        }
+
+        Board board = Board.builder()
+                .userId(session.userId())
+                .title(title)
+                .category(ChatMode.PRODUCT)
+                .description(summaryDescription)
+                .keywords(keywords)
+                .build();
+
+        for (ProductSummaryResponse p : result.products()) {
+            BoardProduct product = BoardProduct.builder()
+                    .productId(p.productId())
+                    .name(p.name())
+                    .imageUrl(p.imageUrl())
+                    .reason(p.reason())
+                    .advantage(p.advantage())
+                    .mood(p.mood())
+                    .recommendedPlace(p.recommendedPlace())
+                    .build();
+            board.addProduct(product);
+        }
+
+        return boardRepository.save(board).getId();
+    }
+
+    private String buildDescription(String moodDesc, String summary) {
+        StringBuilder sb = new StringBuilder();
+        if (moodDesc != null && !moodDesc.isBlank()) {
+            sb.append(moodDesc).append("\n\n");
+        }
+        if (summary != null && !summary.isBlank()) {
+            sb.append("[AI 요약]\n").append(summary);
+        }
+        return sb.toString();
+    }
+
+    private String generateDefaultTitle(String suffix) {
+        return LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd ")) + suffix;
+    }
+
+    public Page<BoardListResponse> getBoardList(Long userId, Pageable pageable) {
+        Page<Board> boardPage = boardRepository.findAllByUserId(userId, pageable);
+
+        return boardPage.map(BoardListResponse::from);
+    }
+}

--- a/src/main/java/com/roome/roome/be/domain/board/service/BoardService.java
+++ b/src/main/java/com/roome/roome/be/domain/board/service/BoardService.java
@@ -105,7 +105,7 @@ public class BoardService {
             throw new GeneralException(ErrorStatus.RESULT_NOT_FOUND);
         }
 
-        String title = generateDefaultTitle(" 맞춤 제품 추천");
+        String title = generateDefaultTitle("맞춤 제품 추천");
 
         String summaryDescription = result.products().stream()
                 .findFirst()

--- a/src/main/java/com/roome/roome/be/domain/chat/model/ChatSession.java
+++ b/src/main/java/com/roome/roome/be/domain/chat/model/ChatSession.java
@@ -1,17 +1,21 @@
 package com.roome.roome.be.domain.chat.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.roome.roome.be.domain.chat.dto.response.ChatProductScenarioResponse;
+import com.roome.roome.be.domain.chat.dto.response.ChatReferenceScenarioResponse;
 import com.roome.roome.be.domain.chat.enums.ChatMode;
 import com.roome.roome.be.domain.chat.enums.ChatTask;
 import com.roome.roome.be.domain.chat.enums.MissingField;
 import com.roome.roome.be.domain.product.enums.ProductCategory;
 import com.roome.roome.be.domain.product.enums.ProductType;
 import com.roome.roome.be.domain.reference.enums.*;
+import lombok.Builder; // [필수] 추가됨
 
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
+@Builder(toBuilder = true)
 public record ChatSession(
 
         /* =========================
@@ -25,8 +29,8 @@ public record ChatSession(
         /* =========================
          * PRODUCT (제품 추천)
          * ========================= */
-        ProductType productType,                 // [수정] 대분류 (단일 값)
-        List<ProductCategory> productCategories, // [수정] 소분류 (리스트)
+        ProductType productType,
+        List<ProductCategory> productCategories,
         List<String> productColors,
         Integer productMinBudget,
         Integer productMaxBudget,
@@ -40,100 +44,70 @@ public record ChatSession(
         List<ReferenceStyle> referenceStyles,
         ReferenceColor referenceColor,
         Integer referenceMinBudget,
-        Integer referenceMaxBudget
+        Integer referenceMaxBudget,
+
+        /* =========================
+         * [추가됨] 결과 저장용 필드
+         * ========================= */
+        ChatProductScenarioResponse lastProductResult,
+        ChatReferenceScenarioResponse lastReferenceResult
+
 ) {
 
     /* =========================
      * 생성 (Factory Method)
      * ========================= */
     public static ChatSession create(Long userId) {
-        return new ChatSession(
-                userId,
-                ChatMode.UNDECIDED,
-                ChatTask.UNDECIDED,
-                Instant.now(),
-
-                // Product 초기값
-                null,           // productType
-                List.of(),      // productCategories
-                List.of(),      // productColors
-                null,           // minBudget
-                null,           // maxBudget
-
-                // Reference 초기값
-                null,
-                null,
-                List.of(),
-                List.of(),
-                null,
-                null,
-                null
-        );
+        return ChatSession.builder()
+                .userId(userId)
+                .mode(ChatMode.UNDECIDED)
+                .task(ChatTask.UNDECIDED)
+                .updatedAt(Instant.now())
+                // 리스트는 빈 리스트로 초기화
+                .productCategories(List.of())
+                .productColors(List.of())
+                .referenceMoods(List.of())
+                .referenceStyles(List.of())
+                .build();
     }
 
     /* =========================
-     * 상태 갱신 (불변 객체이므로 새 객체 반환)
+     * 상태 갱신 (toBuilder 이용)
      * ========================= */
 
     /**
-     * 모드 변경 (기존 데이터 유지)
+     * 모드 변경
      */
     public ChatSession withMode(ChatMode mode) {
-        return new ChatSession(
-                userId,
-                mode,
-                task,
-                Instant.now(),
-
-                // Product 필드 유지
-                productType,
-                productCategories,
-                productColors,
-                productMinBudget,
-                productMaxBudget,
-
-                // Reference 필드 유지
-                referenceType,
-                referenceSize,
-                referenceMoods,
-                referenceStyles,
-                referenceColor,
-                referenceMinBudget,
-                referenceMaxBudget
-        );
+        // 기존 값은 그대로 두고(복사), mode랑 time만 바꿉니다.
+        return this.toBuilder()
+                .mode(mode)
+                .updatedAt(Instant.now())
+                .build();
     }
 
     /**
-     * Product 정보 업데이트 (수정된 필드 반영)
+     * Product 정보 업데이트
      */
     public ChatSession withProductInfo(
-            ProductType productType,                // [변경]
-            List<ProductCategory> productCategories,// [변경]
+            ProductType productType,
+            List<ProductCategory> productCategories,
             List<String> productColors,
             Integer minBudget,
             Integer maxBudget
     ) {
-        return new ChatSession(
-                userId,
-                ChatMode.PRODUCT,
-                ChatTask.PRODUCT_COLLECTING,
-                Instant.now(),
-
-                productType,        // 업데이트
-                productCategories,  // 업데이트
-                productColors,
-                minBudget,
-                maxBudget,
-
-                // Reference 유지
-                referenceType,
-                referenceSize,
-                referenceMoods,
-                referenceStyles,
-                referenceColor,
-                referenceMinBudget,
-                referenceMaxBudget
-        );
+        return this.toBuilder()
+                .mode(ChatMode.PRODUCT)
+                .task(ChatTask.PRODUCT_COLLECTING)
+                .updatedAt(Instant.now())
+                .productType(productType)
+                .productCategories(productCategories)
+                .productColors(productColors)
+                .productMinBudget(minBudget)
+                .productMaxBudget(maxBudget)
+                // 만약 조건이 바뀌면 기존 추천 결과는 지우는 게 좋다면:
+                // .lastProductResult(null)
+                .build();
     }
 
     /**
@@ -148,60 +122,31 @@ public record ChatSession(
             Integer minBudget,
             Integer maxBudget
     ) {
-        return new ChatSession(
-                userId,
-                ChatMode.REFERENCE,
-                ChatTask.REFERENCE_COLLECTING,
-                Instant.now(),
-
-                // Product 유지
-                productType,
-                productCategories,
-                productColors,
-                productMinBudget,
-                productMaxBudget,
-
-                type,
-                size,
-                moods,
-                styles,
-                color,
-                minBudget,
-                maxBudget
-        );
+        return this.toBuilder()
+                .mode(ChatMode.REFERENCE)
+                .task(ChatTask.REFERENCE_COLLECTING)
+                .updatedAt(Instant.now())
+                .referenceType(type)
+                .referenceSize(size)
+                .referenceMoods(moods)
+                .referenceStyles(styles)
+                .referenceColor(color)
+                .referenceMinBudget(minBudget)
+                .referenceMaxBudget(maxBudget)
+                .build();
     }
 
     public ChatSession withTask(ChatTask task) {
-        return new ChatSession(
-                userId,
-                mode,
-                task,
-                Instant.now(),
-
-                productType,
-                productCategories,
-                productColors,
-                productMinBudget,
-                productMaxBudget,
-
-                referenceType,
-                referenceSize,
-                referenceMoods,
-                referenceStyles,
-                referenceColor,
-                referenceMinBudget,
-                referenceMaxBudget
-        );
+        return this.toBuilder()
+                .task(task)
+                .updatedAt(Instant.now())
+                .build();
     }
 
-
     /* =========================
-     * 추천 가능 여부 판단
+     * 추천 가능 여부 판단 (기존 로직 유지)
      * ========================= */
-
     public boolean canRecommendProduct() {
-        // 대분류(Type)가 있고, 예산 범위 중 하나라도 있으면 추천 가능
-        // (소분류 Category는 비어있으면 '전체'로 간주하므로 필수가 아님)
         return productType != null
                 && (productMinBudget != null || productMaxBudget != null);
     }
@@ -213,47 +158,33 @@ public record ChatSession(
     }
 
     /* =========================
-     * 누락 필드 확인 (질문 순서 제어)
+     * 누락 필드 확인 (기존 로직 유지)
      * ========================= */
-
     public List<MissingField> missingProductFields() {
         List<MissingField> missing = new ArrayList<>();
-
-        // 1. 대분류 먼저 확인
-        if (productType == null) {
-            missing.add(MissingField.PRODUCT_TYPE);
-        }
-        // 2. 대분류가 있다면 -> 소분류 확인 (선택 안했으면 물어봄)
+        if (productType == null) missing.add(MissingField.PRODUCT_TYPE);
         else if (productCategories == null || productCategories.isEmpty()) {
             missing.add(MissingField.PRODUCT_DETAIL_CATEGORY);
         }
-
-        // 3. 예산 확인
         if (productMinBudget == null && productMaxBudget == null) {
             missing.add(MissingField.PRODUCT_BUDGET);
         }
-
-        // 4. 컬러 확인
         if (productColors == null || productColors.isEmpty()) {
             missing.add(MissingField.PRODUCT_COLOR_MOOD);
         }
-
         return missing;
     }
 
     public List<MissingField> missingReferenceFields() {
         List<MissingField> missing = new ArrayList<>();
-
         if (referenceType == null) missing.add(MissingField.REFERENCE_TYPE);
         if (referenceSize == null) missing.add(MissingField.REFERENCE_SIZE);
         if (referenceMoods == null || referenceMoods.isEmpty()) missing.add(MissingField.REFERENCE_MOOD);
         if (referenceStyles == null || referenceStyles.isEmpty()) missing.add(MissingField.REFERENCE_STYLE);
         if (referenceColor == null) missing.add(MissingField.REFERENCE_COLOR);
-
         if (referenceMinBudget == null && referenceMaxBudget == null) {
             missing.add(MissingField.REFERENCE_BUDGET);
         }
-
         return missing;
     }
 

--- a/src/main/java/com/roome/roome/be/domain/chat/service/ChatRecommendService.java
+++ b/src/main/java/com/roome/roome/be/domain/chat/service/ChatRecommendService.java
@@ -42,13 +42,10 @@ public class ChatRecommendService {
         Long userId = request.userId();
         User user = userService.getUserById(userId);
 
-        // 1. 공간 & 평수에 맞는 카테고리(가구 종류) 필터링
-        // (예: 거실 -> 소파, TV장 / 주방 -> 식탁)
         List<ReferenceCategoryMapping> matchedCategories = Arrays.stream(ReferenceCategoryMapping.values())
                 .filter(category -> category.isMatch(request.referenceType(), request.referenceSize()))
                 .toList();
 
-        // 매칭된 게 없으면 기본값 세팅 (잘 하셨습니다!)
         if(matchedCategories.isEmpty()) {
             matchedCategories = List.of(
                     ReferenceCategoryMapping.LIGHTING_LED_BULB,
@@ -56,7 +53,6 @@ public class ChatRecommendService {
             );
         }
 
-        // 2. 무드 & 스타일: AI가 준 Enum 그대로 사용
         Set<ReferenceMood> referenceMoodList = new HashSet<>(request.referenceMood());
         Set<ReferenceStyle> referenceStyleList = new HashSet<>(request.referenceStyle());
 
@@ -84,11 +80,9 @@ public class ChatRecommendService {
 
     public ChatProductScenarioResponse processChatProductScenario(ChatProductScenarioRequest request) {
         Long userId = request.userId();
-        // 1. 카테고리 변환
         List<ProductCategory> categories =
                 ProductTypeMapper.getProductCategoryList(request.productTypes());
 
-        // 2. 상품 조회 (여기서 필터 끝)
         List<CandidateProductInfo> candidateProductList =
                 productService.getCandidateProductList(
                         request.maxBudget(),
@@ -101,13 +95,11 @@ public class ChatRecommendService {
             return ChatProductScenarioResponse.from(List.of());
         }
 
-        // 3. AI 추천
         List<AiProductResponse> aiResult =
                 aiService.recommendProductList(
                         AiProductRequest.from(request, candidateProductList, categories )
                 );
 
-        // 4. productId → entity 매핑
         Map<Long, CandidateProductInfo> map =
                 candidateProductList.stream()
                         .collect(Collectors.toMap(
@@ -115,7 +107,6 @@ public class ChatRecommendService {
                                 Function.identity()
                         ));
 
-        // 5. 응답 조립
         List<ProductSummaryResponse> result =
                 aiResult.stream()
                         .map(ai -> {

--- a/src/main/java/com/roome/roome/be/domain/chat/service/ChatService.java
+++ b/src/main/java/com/roome/roome/be/domain/chat/service/ChatService.java
@@ -10,6 +10,7 @@ import com.roome.roome.be.domain.chat.enums.ChatMode;
 import com.roome.roome.be.domain.chat.enums.MissingField;
 import com.roome.roome.be.domain.chat.model.ChatDecision;
 import com.roome.roome.be.domain.chat.model.ChatSession;
+import com.roome.roome.be.domain.chat.repository.ChatSessionRepository;
 import com.roome.roome.be.domain.product.enums.ProductType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -24,6 +25,8 @@ import static com.roome.roome.be.domain.chat.enums.MissingField.PRODUCT_TYPE;
 @RequiredArgsConstructor
 @Slf4j
 public class ChatService {
+
+    private final ChatSessionRepository chatSessionRepository;
 
     private final ChatSessionService chatSessionService;
     private final ChatRecommendService chatRecommendService;
@@ -60,13 +63,20 @@ public class ChatService {
                 return askProductByMissingField(sessionId, session);
             }
 
+            ChatProductScenarioResponse resultData = chatRecommendService.processChatProductScenario(
+                    ChatProductScenarioRequest.create(session)
+            );
+            ChatSession updatedSession = session.toBuilder()
+                    .lastProductResult(resultData)
+                    .build();
+
+            chatSessionRepository.save(sessionId, updatedSession);
+
             return ChatMessageResponse.result(
                     sessionId,
                     "조건에 맞는 제품을 추천해드릴게요!",
                     List.of("추천 결과 보기"),
-                    chatRecommendService.processChatProductScenario(
-                            ChatProductScenarioRequest.create(session)
-                    )
+                    resultData
             );
         }
 
@@ -76,13 +86,21 @@ public class ChatService {
                 return askReferenceByMissingField(sessionId, session);
             }
 
+            ChatReferenceScenarioResponse resultData = chatRecommendService.processChatReferenceScenario(
+                    ChatReferenceScenarioRequest.create(session)
+            );
+
+            ChatSession updatedSession = session.toBuilder()
+                    .lastReferenceResult(resultData)
+                    .build();
+
+            chatSessionRepository.save(sessionId, updatedSession);
+
             return ChatMessageResponse.result(
                     sessionId,
                     "인테리어 추천을 준비했어요 🙂",
                     List.of("추천 결과 보기"),
-                    chatRecommendService.processChatReferenceScenario(
-                            ChatReferenceScenarioRequest.create(session)
-                    )
+                    resultData
             );
         }
 
@@ -101,18 +119,15 @@ public class ChatService {
 
         return switch (field) {
 
-            // [1단계] 대분류 선택 (ProductType)
             case PRODUCT_TYPE -> ChatMessageResponse.question(
                     sessionId,
                     "어떤 종류의 제품을 찾고 계신가요?",
-                    List.of("가구", "조명", "패브릭 & 데코", "커튼 & 블라인드") // 버튼 클릭 시 ProductType 매핑
+                    List.of("가구", "조명", "패브릭 & 데코", "커튼 & 블라인드")
             );
 
-            // 상세 품목 선택 (ProductCategory) - 앞 단계 선택값에 따라 분기
             case PRODUCT_DETAIL_CATEGORY -> {
-                ProductType type = session.productType(); // 이미 저장된 대분류 가져오기
+                ProductType type = session.productType();
 
-                // 대분류에 따라 보여줄 상세 버튼 목록 결정
                 List<String> buttons = switch (type) {
                     case FURNITURE -> List.of("책상", "테이블", "의자", "스툴");
                     case LIGHTING -> List.of("천장등", "독서등", "장식 조명");

--- a/src/main/java/com/roome/roome/be/domain/product/service/ProductService.java
+++ b/src/main/java/com/roome/roome/be/domain/product/service/ProductService.java
@@ -97,22 +97,18 @@ public class ProductService {
         return product.getId();
     }
 
-    // 상품 상세 조회 (리팩토링됨)
+    // 상품 상세 조회
     @Transactional
     public ProductDetailResponse getProductDetail(Long productId, Long userId) {
-        // 1. 데이터 조회
         Product product = getProductById(productId);
         List<ProductImage> images = productImageRepository.findByProductIdOrderBySortOrder(productId);
         List<ProductTag> productTags = productTagRepository.findByProductIdWithTag(productId);
 
-        // 2. 유저 조회 기록 저장
         userViewService.registerUserView(product, userId);
 
-        // 3. 좋아요/스크랩 여부 확인
         boolean isLiked = (userId != null) && userLikeProductRepository.existsByUserIdAndProductId(userId, productId);
         boolean isScrapped = (userId != null) && userScrapProductRepository.existsByUserIdAndProductId(userId, productId);
 
-        // 4. 연관 상품 조회
         ProductCategory category = productTags.stream()
                 .map(pt -> pt.getTag())
                 .filter(t -> t.getType() == TagType.PRODUCT_TYPE)
@@ -123,7 +119,6 @@ public class ProductService {
         List<Long> tagIdList = productTags.stream().map(pt -> pt.getTag().getId()).toList();
         List<RelatedProductResponse> relatedProductList = productRepository.findRelatedProductList(productId, category, tagIdList);
 
-        // 5. 변환
         return productMapper.toDetailResponse(product, images, productTags, relatedProductList, isLiked, isScrapped);
     }
 
@@ -151,7 +146,6 @@ public class ProductService {
 
         if (pageSize <= 0) throw new GeneralException(ErrorStatus.BAD_REQUEST);
 
-        // sort 파라미터를 명시했는지 여부
         boolean hasSortParam = !pageable.getSort().isUnsorted();
 
         Map<TagType, List<String>> explicitTagFilters = new HashMap<>();
@@ -167,7 +161,6 @@ public class ProductService {
             || (shopId != null)
             || (!explicitTagFilters.isEmpty());
 
-        // 필터 있거나 sort 있으면  추천 스킵
         if (hasExplicitFilters || hasSortParam ) {
             Page<Product> page = productRepository.findByDynamicFilters(
                 shopId, category, keyWord, minPrice, maxPrice,
@@ -197,7 +190,6 @@ public class ProductService {
             return mapToListItemPage(page, userId);
         }
 
-        // 온보딩 추천 +. 추천 이어서 나머지 모두 id desc로 정렬(기본 정렬)
         Sort bucketSort = Sort.by(Sort.Direction.DESC, "id");
 
         long recTotal = productRepository.countByDynamicFilters(


### PR DESCRIPTION
## #️⃣ 관련 이슈
closed #115 

## 💡 작업 배경


## 🧩 작업 내용
ChatMode가 PRODUCT일 경우 BoardProduct 테이블에서, REFERENCE일 경우 BoardReference 테이블에서 이미지를 가져오도록 함

keyword 부분에 레퍼런스는 무드, 
상품 추천은 장소 담았습니당

## 📸 스크린샷(선택)
<img width="2836" height="982" alt="image" src="https://github.com/user-attachments/assets/1d0d1334-2020-4ed7-be1d-0528cd05f9a8" />


- 세션 아이디를 통한 저장
<img width="1409" height="475" alt="image" src="https://github.com/user-attachments/assets/3f783a63-900e-4d0f-9e11-0b228e84f94e" />

<img width="2860" height="1164" alt="image" src="https://github.com/user-attachments/assets/e18d2126-0581-4959-bc9d-f56795c734b3" />


-  레퍼런스, 상품 챗봇 추천 목록 조회
## 📝 기타


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Save chat conversations as boards for later reference.
  * View a paginated list of saved boards with images, products, keywords, and timestamps.
  * Session recommendation results are now persisted and available for retrieval and board creation.

* **Bug Fixes**
  * New error responses for invalid sessions, session ownership mismatches, and missing results.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->